### PR TITLE
[fix]Fixed the problem that the kafka topic contained dot characters

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/writer/LabelGenerator.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/LabelGenerator.java
@@ -44,9 +44,9 @@ public class LabelGenerator {
             int subtaskId) {
         this(labelPrefix, enable2PC);
         // The label of stream load can not contain `.`
-        this.tableIdentifier = tableIdentifier.replace(".", "_");
+        this.tableIdentifier = tableIdentifier.replaceAll("\\.", "_");
+        this.topic = topic.replaceAll("\\.", "_");
         this.subtaskId = subtaskId;
-        this.topic = topic;
         this.partition = partition;
     }
 

--- a/src/main/java/org/apache/doris/kafka/connector/writer/StreamLoadWriter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/StreamLoadWriter.java
@@ -100,12 +100,13 @@ public class StreamLoadWriter extends DorisWriter {
     @VisibleForTesting
     public Map<String, String> fetchLabel2Status() {
         String queryPatten = String.format(TRANSACTION_LABEL_PATTEN, dorisOptions.getDatabase());
-        String tmpTableIdentifier = tableIdentifier.replace(".", "_");
+        String tmpTableIdentifier = tableIdentifier.replaceAll("\\.", "_");
+        String tmpTopic = topic.replaceAll("\\.", "_");
         String querySQL =
                 queryPatten
                         + dorisOptions.getLabelPrefix()
                         + LoadConstants.FILE_DELIM_DEFAULT
-                        + topic
+                        + tmpTopic
                         + LoadConstants.FILE_DELIM_DEFAULT
                         + partition
                         + LoadConstants.FILE_DELIM_DEFAULT


### PR DESCRIPTION
if kafka topic contained dot characters, which caused the stream load label verification to fail