### PR TITLE
[fix]Fix DateTimeUtils, SchemaUtils referenced packages from debezium-connector-jdbc

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/converter/RecordService.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/RecordService.java
@@ -126,9 +126,9 @@ public class RecordService {
     private void validate(SinkRecord record) {
         if (isSchemaChange(record)) {
             LOG.warn(
-                    "Schema change records are not supported by JDBC connector. Adjust `topics` or `topics.regex` to exclude schema change topic.");
+                    "Schema change records are not supported by doris-kafka-connector. Adjust `topics` or `topics.regex` to exclude schema change topic.");
             throw new DorisException(
-                    "Schema change records are not supported by JDBC connector. Adjust `topics` or `topics.regex` to exclude schema change topic.");
+                    "Schema change records are not supported by doris-kafka-connector. Adjust `topics` or `topics.regex` to exclude schema change topic.");
         }
     }
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/AbstractType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/AbstractType.java
@@ -18,10 +18,10 @@
  */
 package org.apache.doris.kafka.connector.converter.type;
 
-import io.debezium.connector.jdbc.util.SchemaUtils;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
+import org.apache.doris.kafka.connector.converter.type.util.SchemaUtils;
 import org.apache.kafka.connect.data.Schema;
 
 /** An abstract implementation of {@link Type}, which all types should extend. */

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/connect/ConnectDateType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/connect/ConnectDateType.java
@@ -18,8 +18,8 @@
  */
 package org.apache.doris.kafka.connector.converter.type.connect;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import org.apache.doris.kafka.connector.converter.type.AbstractDateType;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.errors.ConnectException;
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/connect/ConnectTimeType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/connect/ConnectTimeType.java
@@ -18,12 +18,12 @@
  */
 package org.apache.doris.kafka.connector.converter.type.connect;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Date;
 import org.apache.doris.kafka.connector.converter.type.AbstractTimeType;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/connect/ConnectTimestampType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/connect/ConnectTimestampType.java
@@ -18,8 +18,8 @@
  */
 package org.apache.doris.kafka.connector.converter.type.connect;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import org.apache.doris.kafka.connector.converter.type.AbstractTimestampType;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/DateType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/DateType.java
@@ -18,9 +18,9 @@
  */
 package org.apache.doris.kafka.connector.converter.type.debezium;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import io.debezium.time.Date;
 import org.apache.doris.kafka.connector.converter.type.AbstractDateType;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 
 public class DateType extends AbstractDateType {

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/MicroTimeType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/MicroTimeType.java
@@ -18,9 +18,9 @@
  */
 package org.apache.doris.kafka.connector.converter.type.debezium;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import io.debezium.time.MicroTime;
 import java.time.LocalTime;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 
 public class MicroTimeType extends AbstractDebeziumTimeType {
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/MicroTimestampType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/MicroTimestampType.java
@@ -18,9 +18,9 @@
  */
 package org.apache.doris.kafka.connector.converter.type.debezium;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import io.debezium.time.MicroTimestamp;
 import java.time.LocalDateTime;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 
 public class MicroTimestampType extends AbstractDebeziumTimestampType {
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/NanoTimeType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/NanoTimeType.java
@@ -18,9 +18,9 @@
  */
 package org.apache.doris.kafka.connector.converter.type.debezium;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import io.debezium.time.NanoTime;
 import java.time.LocalTime;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 
 public class NanoTimeType extends AbstractDebeziumTimeType {
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/NanoTimestampType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/NanoTimestampType.java
@@ -18,10 +18,10 @@
  */
 package org.apache.doris.kafka.connector.converter.type.debezium;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import io.debezium.time.MicroTimestamp;
 import io.debezium.time.NanoTimestamp;
 import java.time.LocalDateTime;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 
 /**
  * An implementation of {@link org.apache.doris.kafka.connector.converter.type.Type} for {@link

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/TimeType.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/debezium/TimeType.java
@@ -18,9 +18,9 @@
  */
 package org.apache.doris.kafka.connector.converter.type.debezium;
 
-import io.debezium.connector.jdbc.util.DateTimeUtils;
 import io.debezium.time.Time;
 import java.time.LocalTime;
+import org.apache.doris.kafka.connector.converter.type.util.DateTimeUtils;
 
 public class TimeType extends AbstractDebeziumTimeType {
 

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/util/DateTimeUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/util/DateTimeUtils.java
@@ -18,9 +18,10 @@
  *
  * Copied from
  * https://github.com/debezium/debezium-connector-jdbc/blob/main/src/main/java/io/debezium/connector/jdbc/util/DateTimeUtils.java
+ * modified by doris.
  */
 
-package io.debezium.connector.jdbc.util;
+package org.apache.doris.kafka.connector.converter.type.util;
 
 import io.debezium.time.Conversions;
 import java.sql.Timestamp;

--- a/src/main/java/org/apache/doris/kafka/connector/converter/type/util/SchemaUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/converter/type/util/SchemaUtils.java
@@ -18,9 +18,10 @@
  *
  * Copied from
  * https://github.com/debezium/debezium-connector-jdbc/blob/main/src/main/java/io/debezium/connector/jdbc/util/SchemaUtils.java
+ * modified by doris.
  */
 
-package io.debezium.connector.jdbc.util;
+package org.apache.doris.kafka.connector.converter.type.util;
 
 import java.util.Objects;
 import java.util.Optional;


### PR DESCRIPTION
Since the `DateTimeUtils` and `SchemaUtils` classes in debezium-connector-jdbc are somewhat different from those in this project, when they are inconsistent, a null pointer exception will occur, so the package reference has been changed.