### PR TITLE
[Improve]schema.evolution adds debezium prefix

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
@@ -95,8 +95,8 @@ public class DorisOptions {
         this.schemaEvolutionMode =
                 SchemaEvolutionMode.of(
                         config.getOrDefault(
-                                DorisSinkConnectorConfig.SCHEMA_EVOLUTION,
-                                DorisSinkConnectorConfig.SCHEMA_EVOLUTION_DEFAULT));
+                                DorisSinkConnectorConfig.DEBEZIUM_SCHEMA_EVOLUTION,
+                                DorisSinkConnectorConfig.DEBEZIUM_SCHEMA_EVOLUTION_DEFAULT));
 
         this.fileSize = Integer.parseInt(config.get(DorisSinkConnectorConfig.BUFFER_SIZE_BYTES));
         this.recordNum =

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
@@ -82,8 +82,9 @@ public class DorisSinkConnectorConfig {
 
     // Prefix for Doris StreamLoad specific properties.
     public static final String STREAM_LOAD_PROP_PREFIX = "sink.properties.";
-    public static final String SCHEMA_EVOLUTION = "schema.evolution";
-    public static final String SCHEMA_EVOLUTION_DEFAULT = SchemaEvolutionMode.NONE.getName();
+    public static final String DEBEZIUM_SCHEMA_EVOLUTION = "debezium.schema.evolution";
+    public static final String DEBEZIUM_SCHEMA_EVOLUTION_DEFAULT =
+            SchemaEvolutionMode.NONE.getName();
 
     // metrics
     public static final String JMX_OPT = "jmx";

--- a/src/test/java/org/apache/doris/kafka/connector/converter/TestRecordService.java
+++ b/src/test/java/org/apache/doris/kafka/connector/converter/TestRecordService.java
@@ -72,7 +72,7 @@ public class TestRecordService {
         props.load(stream);
         props.put("task_id", "1");
         props.put("converter.mode", "debezium_ingestion");
-        props.put("schema.evolution", "basic");
+        props.put("debezium.schema.evolution", "basic");
         props.put(
                 "doris.topic2table.map",
                 "avro_schema.wdl_test.example_table:example_table,normal.wdl_test.test_sink_normal:test_sink_normal");


### PR DESCRIPTION
Since this parameter is only used when ```converter.mode=debezium_ingestion```, add the debezium prefix to ``schema.evolution`` to become ```debezium.schema.evolution``` to avoid misunderstandings