### PR TITLE
[Improve]Optimize to determine whether table in doris exists

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/service/DorisSystemService.java
+++ b/src/main/java/org/apache/doris/kafka/connector/service/DorisSystemService.java
@@ -22,8 +22,10 @@ package org.apache.doris.kafka.connector.service;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
@@ -45,29 +47,31 @@ public class DorisSystemService {
             Collections.singletonList("information_schema");
 
     public boolean tableExists(String database, String table) {
-        return databaseExists(database) && listTables(database).contains(table);
+        return listTables(database).contains(table);
     }
 
     public boolean databaseExists(String database) {
         return listDatabases().contains(database);
     }
 
-    public List<String> listDatabases() {
-        return extractColumnValuesBySQL(
-                "SELECT `SCHEMA_NAME` FROM `INFORMATION_SCHEMA`.`SCHEMATA`;",
-                1,
-                dbName -> !builtinDatabases.contains(dbName));
+    public Set<String> listDatabases() {
+        return new HashSet<>(
+                extractColumnValuesBySQL(
+                        "SELECT `SCHEMA_NAME` FROM `INFORMATION_SCHEMA`.`SCHEMATA`;",
+                        1,
+                        dbName -> !builtinDatabases.contains(dbName)));
     }
 
-    public List<String> listTables(String databaseName) {
+    public Set<String> listTables(String databaseName) {
         if (!databaseExists(databaseName)) {
             throw new DorisException("database" + databaseName + " is not exists");
         }
-        return extractColumnValuesBySQL(
-                "SELECT TABLE_NAME FROM information_schema.`TABLES` WHERE TABLE_SCHEMA = ?",
-                1,
-                null,
-                databaseName);
+        return new HashSet<>(
+                extractColumnValuesBySQL(
+                        "SELECT TABLE_NAME FROM information_schema.`TABLES` WHERE TABLE_SCHEMA = ?",
+                        1,
+                        null,
+                        databaseName));
     }
 
     public List<String> extractColumnValuesBySQL(


### PR DESCRIPTION
Since each partition under the topic has a sink task, when the corresponding connector starts, it will connect to doris to determine whether the table exists.
When there are multiple topics, and each topic has multiple partitions, a large number of connections will be made to request doris at the moment of startup, causing the number of connections to exceed the limit.

This PR can reduce a repeated request to determine whether the database exists.