### PR TITLE
[feature]Implement DorisAvroConverter to support parsing schema from avro avsc file path

### DIFF
--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Check License
         uses: apache/skywalking-eyes@v0.2.0
         with:
-          config-path: ./license-eye-ignore.yml
+          config-path: ./.licenserc.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,7 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-license:
-  ignore_paths:
-    - src/test/resources/decode/avro/user.avsc
-    - src/test/resources/decode/avro/product.avsc
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Apache Software Foundation
+
+  paths-ignore:
+    - 'LICENSE'
+    - '.gitignore'
+    - 'src/test/resources/decode/avro/**'
+
+  comment: on-failure

--- a/license-eye-ignore.yml
+++ b/license-eye-ignore.yml
@@ -15,26 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
----
-name: License Check
-on:
-  pull_request:
-  push:
-    branches:
-      - master
 
-jobs:
-  license-check:
-    name: "License Check"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
-
-      - name: Check License
-        uses: apache/skywalking-eyes@v0.2.0
-        with:
-          config-path: ./license-eye-ignore.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+license:
+  ignore_paths:
+    - src/test/resources/decode/avro/user.avsc
+    - src/test/resources/decode/avro/product.avsc

--- a/src/main/java/org/apache/doris/kafka/connector/decode/DorisConverter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/decode/DorisConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.decode;
+
+import java.util.Map;
+import org.apache.doris.kafka.connector.exception.DataDecodeException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.storage.Converter;
+
+public abstract class DorisConverter implements Converter {
+
+    /** unused */
+    @Override
+    public void configure(final Map<String, ?> map, final boolean b) {
+        // not necessary
+    }
+
+    /** doesn't support data source connector */
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        throw new DataDecodeException("DorisConverter doesn't support data source connector yet.");
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/decode/DorisJsonSchema.java
+++ b/src/main/java/org/apache/doris/kafka/connector/decode/DorisJsonSchema.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.decode;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+
+public class DorisJsonSchema implements Schema {
+    static String NAME = "DORIS_JSON_SCHEMA";
+    static int VERSION = 1;
+
+    @Override
+    public Schema.Type type() {
+        return Type.STRUCT;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public Object defaultValue() {
+        return null;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Integer version() {
+        return VERSION;
+    }
+
+    @Override
+    public String doc() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> parameters() {
+        return null;
+    }
+
+    @Override
+    public Schema keySchema() {
+        return null;
+    }
+
+    @Override
+    public Schema valueSchema() {
+        return null;
+    }
+
+    @Override
+    public List<Field> fields() {
+        return null;
+    }
+
+    @Override
+    public Field field(final String s) {
+        return null;
+    }
+
+    @Override
+    public Schema schema() {
+        return null;
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverter.java
@@ -147,11 +147,7 @@ public class DorisAvroConverter extends DorisConverter {
         if (topic2SchemaMap.containsKey(topic)) {
             Schema schema = topic2SchemaMap.get(topic);
             ByteBuffer buffer = ByteBuffer.wrap(value);
-            if (buffer.get() != 0) {
-                throw new DataDecodeException("Input record value can't be parsed.");
-            }
-            int id = buffer.getInt();
-            int length = buffer.limit() - 1 - 4;
+            int length = buffer.limit();
             byte[] data = new byte[length];
             buffer.get(data, 0, length);
             try {

--- a/src/main/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverter.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
@@ -50,7 +49,6 @@ import org.slf4j.LoggerFactory;
  */
 public class DorisAvroConverter extends DorisConverter {
     public static final String AVRO_TOPIC_SCHEMA_FILEPATH = "avro.topic2schema.filepath";
-    public static final String AVRO_CONVERTER_TEST = "avro.converter.test";
     private static final Logger LOG = LoggerFactory.getLogger(DorisAvroConverter.class);
     private final Map<String, Schema> topic2SchemaMap = new HashMap<>();
 
@@ -74,22 +72,9 @@ public class DorisAvroConverter extends DorisConverter {
             for (Map.Entry<String, String> entry : topic2SchemaFileMap.entrySet()) {
                 String topic = entry.getKey();
                 String schemaPath = entry.getValue();
-                Schema schema = null;
+                Schema schema;
                 try {
-                    if (configs.containsKey(AVRO_CONVERTER_TEST)) {
-                        // Used for junit testing to load resource files
-                        if (Boolean.parseBoolean((String) configs.get(AVRO_CONVERTER_TEST))) {
-                            String resourcePath =
-                                    Objects.requireNonNull(
-                                                    this.getClass()
-                                                            .getClassLoader()
-                                                            .getResource(schemaPath))
-                                            .getPath();
-                            schema = new Schema.Parser().parse(new File(resourcePath));
-                        }
-                    } else {
-                        schema = new Schema.Parser().parse(new File(schemaPath));
-                    }
+                    schema = new Schema.Parser().parse(new File(schemaPath));
                 } catch (SchemaParseException | IOException e) {
                     LOG.error(
                             "the provided for "
@@ -189,7 +174,7 @@ public class DorisAvroConverter extends DorisConverter {
      *
      * @param data avro data
      * @param writerSchema avro schema with which data got serialized
-     * @param readerSchema avro schema that describes the shape of the returned JsonNode
+     * @param readerSchema avro schema with which will to be read and returned
      */
     private String parseAvroWithSchema(final byte[] data, Schema writerSchema, Schema readerSchema)
             throws IOException {

--- a/src/main/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverter.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.decode.avro;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.avro.Conversions;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.doris.kafka.connector.decode.DorisConverter;
+import org.apache.doris.kafka.connector.decode.DorisJsonSchema;
+import org.apache.doris.kafka.connector.exception.DataDecodeException;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Supports specifying the avsc file of avro, can directly obtain the avro schema by parsing the
+ * file.
+ */
+public class DorisAvroConverter extends DorisConverter {
+    public static final String AVRO_TOPIC_SCHEMA_FILEPATH = "avro.topic2schema.filepath";
+    public static final String AVRO_CONVERTER_TEST = "avro.converter.test";
+    private static final Logger LOG = LoggerFactory.getLogger(DorisAvroConverter.class);
+    private final Map<String, Schema> topic2SchemaMap = new HashMap<>();
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+        parseTopic2Schema(configs);
+    }
+
+    @VisibleForTesting
+    public void parseTopic2Schema(final Map<String, ?> configs) {
+        Object avroSchemaPath = configs.get(AVRO_TOPIC_SCHEMA_FILEPATH);
+
+        if (avroSchemaPath == null) {
+            LOG.error(AVRO_TOPIC_SCHEMA_FILEPATH + " can not be empty in DorisAvroConverter.class");
+            throw new DataDecodeException(
+                    AVRO_TOPIC_SCHEMA_FILEPATH + " can not be empty in DorisAvroConverter.class");
+        }
+
+        if (avroSchemaPath instanceof String) {
+            Map<String, String> topic2SchemaFileMap = parseTopicSchemaPath((String) avroSchemaPath);
+            for (Map.Entry<String, String> entry : topic2SchemaFileMap.entrySet()) {
+                String topic = entry.getKey();
+                String schemaPath = entry.getValue();
+                Schema schema = null;
+                try {
+                    if (configs.containsKey(AVRO_CONVERTER_TEST)) {
+                        // Used for junit testing to load resource files
+                        if (Boolean.parseBoolean((String) configs.get(AVRO_CONVERTER_TEST))) {
+                            String resourcePath =
+                                    Objects.requireNonNull(
+                                                    this.getClass()
+                                                            .getClassLoader()
+                                                            .getResource(schemaPath))
+                                            .getPath();
+                            schema = new Schema.Parser().parse(new File(resourcePath));
+                        }
+                    } else {
+                        schema = new Schema.Parser().parse(new File(schemaPath));
+                    }
+                } catch (SchemaParseException | IOException e) {
+                    LOG.error(
+                            "the provided for "
+                                    + AVRO_TOPIC_SCHEMA_FILEPATH
+                                    + " is no valid, failed to parse {} {}",
+                            topic,
+                            schemaPath,
+                            e);
+                    throw new DataDecodeException(
+                            "the provided for "
+                                    + AVRO_TOPIC_SCHEMA_FILEPATH
+                                    + " is no valid, failed to parse "
+                                    + topic
+                                    + " "
+                                    + schemaPath
+                                    + ".\n",
+                            e);
+                }
+                topic2SchemaMap.put(topic, schema);
+            }
+        } else {
+            LOG.error(AVRO_TOPIC_SCHEMA_FILEPATH + " must be a string.");
+            throw new DataDecodeException(
+                    "The "
+                            + AVRO_TOPIC_SCHEMA_FILEPATH
+                            + " is provided, but can not be parsed as an Avro schema.");
+        }
+    }
+
+    /**
+     * Parse the mapping between topic and schema file paths.
+     *
+     * @param topicSchemaPath topic1:file:///schema_test.avsc,topic2:file:///schema_test2.avsc
+     */
+    private Map<String, String> parseTopicSchemaPath(String topicSchemaPath) {
+        Map<String, String> topic2SchemaPathMap = new HashMap<>();
+        boolean isInvalid = false;
+        for (String s : topicSchemaPath.split(",")) {
+            String[] split = s.split(":file://");
+            if (split.length != 2 || split[0].trim().isEmpty() || split[1].trim().isEmpty()) {
+                LOG.error(
+                        "Invalid {} config format: {}",
+                        AVRO_TOPIC_SCHEMA_FILEPATH,
+                        topicSchemaPath);
+                isInvalid = true;
+            }
+
+            String topic = split[0].trim();
+            String schemaPath = split[1].trim();
+
+            if (topic2SchemaPathMap.containsKey(topic)) {
+                LOG.error("topic name {} is duplicated.", topic);
+                isInvalid = true;
+            }
+            topic2SchemaPathMap.put(topic, schemaPath);
+        }
+        if (isInvalid) {
+            throw new DataDecodeException("Failed to parse " + AVRO_TOPIC_SCHEMA_FILEPATH + " map");
+        }
+        return topic2SchemaPathMap;
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] value) {
+        if (value == null) {
+            LOG.warn("cast bytes is null");
+            return new SchemaAndValue(new DorisJsonSchema(), null);
+        }
+
+        if (topic2SchemaMap.containsKey(topic)) {
+            Schema schema = topic2SchemaMap.get(topic);
+            ByteBuffer buffer = ByteBuffer.wrap(value);
+            if (buffer.get() != 0) {
+                throw new DataDecodeException("Input record value can't be parsed.");
+            }
+            int id = buffer.getInt();
+            int length = buffer.limit() - 1 - 4;
+            byte[] data = new byte[length];
+            buffer.get(data, 0, length);
+            try {
+                return new SchemaAndValue(
+                        new DorisJsonSchema(), parseAvroWithSchema(data, schema, schema));
+            } catch (IOException e) {
+                LOG.error("failed to parse AVRO record\n" + e);
+                throw new DataDecodeException("failed to parse AVRO record\n", e);
+            }
+        } else {
+            LOG.error("The avro schema file of {} is not provided.", topic);
+            throw new DataDecodeException("The avro schema file of " + topic + " is not provided.");
+        }
+    }
+
+    /**
+     * Parse Avro record with a writer schema and a reader schema. The writer and the reader schema
+     * have to be compatible as described in
+     * https://avro.apache.org/docs/1.9.2/spec.html#Schema+Resolution
+     *
+     * @param data avro data
+     * @param writerSchema avro schema with which data got serialized
+     * @param readerSchema avro schema that describes the shape of the returned JsonNode
+     */
+    private String parseAvroWithSchema(final byte[] data, Schema writerSchema, Schema readerSchema)
+            throws IOException {
+        final GenericData genericData = new GenericData();
+        // Conversion for logical type Decimal.
+        // There are conversions for other logical types as well.
+        genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
+
+        InputStream is = new ByteArrayInputStream(data);
+        Decoder decoder = DecoderFactory.get().binaryDecoder(is, null);
+        DatumReader<GenericRecord> reader =
+                new GenericDatumReader<>(writerSchema, readerSchema, genericData);
+        GenericRecord datum = reader.read(null, decoder);
+        return datum.toString();
+    }
+
+    @VisibleForTesting
+    public Map<String, Schema> getTopic2SchemaMap() {
+        return topic2SchemaMap;
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/exception/DataDecodeException.java
+++ b/src/main/java/org/apache/doris/kafka/connector/exception/DataDecodeException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.exception;
+
+public class DataDecodeException extends DorisException {
+
+    public DataDecodeException(String message) {
+        super(message);
+    }
+
+    public DataDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DataDecodeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverterTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverterTest.java
@@ -42,7 +42,6 @@ public class DorisAvroConverterTest {
     private static final String PRODUCT_AVRO_PATH = "src/test/resources/decode/avro/product.avsc";
     private final DorisAvroConverter avroConverter = new DorisAvroConverter();
     private final Map<String, String> configs = new HashMap<>();
-    private final List<byte[]> records = new ArrayList<>();
 
     @Before
     public void init() {

--- a/src/test/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverterTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverterTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.avro.Schema;
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,8 +31,8 @@ import org.junit.Test;
 public class DorisAvroConverterTest {
     private static final String USER_TOPIC = "user-topic";
     private static final String PRODUCT_TOPIC = "product-topic";
-    private static final String USER_AVRO_PATH = "decode/avro/user.avsc";
-    private static final String PRODUCT_AVRO_PATH = "decode/avro/product.avsc";
+    private static final String USER_AVRO_PATH = "src/test/resources/decode/avro/user.avsc";
+    private static final String PRODUCT_AVRO_PATH = "src/test/resources/decode/avro/product.avsc";
     private final DorisAvroConverter avroConverter = new DorisAvroConverter();
     private final Map<String, String> configs = new HashMap<>();
 
@@ -48,7 +47,6 @@ public class DorisAvroConverterTest {
                         + ":file://"
                         + PRODUCT_AVRO_PATH;
         configs.put(DorisAvroConverter.AVRO_TOPIC_SCHEMA_FILEPATH, topic2SchemaPath);
-        configs.put(DorisAvroConverter.AVRO_CONVERTER_TEST, "true");
     }
 
     @Test
@@ -59,15 +57,8 @@ public class DorisAvroConverterTest {
         Assert.assertTrue(topic2SchemaMap.containsKey(USER_TOPIC));
         Assert.assertTrue(topic2SchemaMap.containsKey(PRODUCT_TOPIC));
 
-        String userPath =
-                Objects.requireNonNull(this.getClass().getClassLoader().getResource(USER_AVRO_PATH))
-                        .getPath();
-        String productPath =
-                Objects.requireNonNull(
-                                this.getClass().getClassLoader().getResource(PRODUCT_AVRO_PATH))
-                        .getPath();
-        Schema productSchema = new Schema.Parser().parse(new File(productPath));
-        Schema userSchema = new Schema.Parser().parse(new File(userPath));
+        Schema productSchema = new Schema.Parser().parse(new File(PRODUCT_AVRO_PATH));
+        Schema userSchema = new Schema.Parser().parse(new File(USER_AVRO_PATH));
         Assert.assertEquals(topic2SchemaMap.get(USER_TOPIC), userSchema);
         Assert.assertEquals(topic2SchemaMap.get(PRODUCT_TOPIC), productSchema);
     }

--- a/src/test/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverterTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/decode/avro/DorisAvroConverterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.decode.avro;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.avro.Schema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DorisAvroConverterTest {
+    private static final String USER_TOPIC = "user-topic";
+    private static final String PRODUCT_TOPIC = "product-topic";
+    private static final String USER_AVRO_PATH = "decode/avro/user.avsc";
+    private static final String PRODUCT_AVRO_PATH = "decode/avro/product.avsc";
+    private final DorisAvroConverter avroConverter = new DorisAvroConverter();
+    private final Map<String, String> configs = new HashMap<>();
+
+    @Before
+    public void init() {
+        String topic2SchemaPath =
+                USER_TOPIC
+                        + ":file://"
+                        + USER_AVRO_PATH
+                        + ", "
+                        + PRODUCT_TOPIC
+                        + ":file://"
+                        + PRODUCT_AVRO_PATH;
+        configs.put(DorisAvroConverter.AVRO_TOPIC_SCHEMA_FILEPATH, topic2SchemaPath);
+        configs.put(DorisAvroConverter.AVRO_CONVERTER_TEST, "true");
+    }
+
+    @Test
+    public void testParseTopicSchema() throws IOException {
+        avroConverter.parseTopic2Schema(configs);
+        Map<String, Schema> topic2SchemaMap = avroConverter.getTopic2SchemaMap();
+
+        Assert.assertTrue(topic2SchemaMap.containsKey(USER_TOPIC));
+        Assert.assertTrue(topic2SchemaMap.containsKey(PRODUCT_TOPIC));
+
+        String userPath =
+                Objects.requireNonNull(this.getClass().getClassLoader().getResource(USER_AVRO_PATH))
+                        .getPath();
+        String productPath =
+                Objects.requireNonNull(
+                                this.getClass().getClassLoader().getResource(PRODUCT_AVRO_PATH))
+                        .getPath();
+        Schema productSchema = new Schema.Parser().parse(new File(productPath));
+        Schema userSchema = new Schema.Parser().parse(new File(userPath));
+        Assert.assertEquals(topic2SchemaMap.get(USER_TOPIC), userSchema);
+        Assert.assertEquals(topic2SchemaMap.get(PRODUCT_TOPIC), productSchema);
+    }
+}

--- a/src/test/resources/decode/avro/product.avsc
+++ b/src/test/resources/decode/avro/product.avsc
@@ -1,0 +1,18 @@
+{
+    "type": "record",
+    "name": "Product",
+    "fields": [
+        {
+            "name": "id",
+            "type": "int"
+        },
+        {
+            "name": "name",
+            "type": "string"
+        },
+        {
+            "name": "price",
+            "type": "double"
+        }
+    ]
+}

--- a/src/test/resources/decode/avro/user.avsc
+++ b/src/test/resources/decode/avro/user.avsc
@@ -1,0 +1,18 @@
+{
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {
+            "name": "id",
+            "type": "int"
+        },
+        {
+            "name": "name",
+            "type": "string"
+        },
+        {
+            "name": "age",
+            "type": "int"
+        }
+    ]
+}


### PR DESCRIPTION
close: https://github.com/apache/doris-kafka-connector/issues/29

Earlier, the file parsing of avro used the `io.confluent.connect.avro.AvroConverter` provided by confluent. This method requires specifying `schema.registry.url` to obtain the schema. Generally speaking, this kind of registration center is provided by confluent. 
At present, it seems that there is some over-reliance on the confluent registration center, so we are open to parsing the schema by reading the avsc file of local avro in order to achieve decoupling from the confluent registration center.

By specifying `value.converter` or  `key.converter` `org.apache.doris.kafka.connector.decode.avro.DorisAvroConverter`.
Configure the parameters of `value.converter.avro.topic2schema.filepath` or `key.converter.avro.topic2schema.filepath`, and change the topic Corresponding to the local avsc file, the avro schema can be parsed.

```
curl -i http://127.0.0.1:8083/connectors -H "Content-Type: application/json" -X POST -d '{ 
  "name":"avro_file_sink-connector", 
  "config":{ 
    "connector.class":"org.apache.doris.kafka.connector.DorisSinkConnector", 
    "topics":"avro-user,avro-product", 
    "tasks.max":"1",
    "doris.topic2table.map": "avro-user:user_tab,avro-product:product_tab", 
    "buffer.count.records":"100", 
    "buffer.flush.time":"10", 
    "buffer.size.bytes":"10000000",
    "doris.urls":"127.0.0.1", 
    "doris.user":"root", 
    "doris.password":"", 
    "doris.http.port":"8030", 
    "doris.query.port":"9030", 
    "doris.database":"test",
    "key.converter":"org.apache.kafka.connect.storage.StringConverter",
    "value.converter":"org.apache.doris.kafka.connector.decode.avro.DorisAvroConverter",
    "value.converter.avro.topic2schema.filepath":"avro-user:file:///opt/avro_user.avsc, avro-product:file:///opt/avro_product.avsc"
  } 
}'
```



