### PR TITLE
[Improve]Improve the unit test case of DorisWriter

### DIFF
--- a/src/test/java/org/apache/doris/kafka/connector/writer/TestCopyIntoWriter.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/TestCopyIntoWriter.java
@@ -32,7 +32,6 @@ import java.util.Properties;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
 import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
 import org.apache.doris.kafka.connector.connection.JdbcConnectionProvider;
-import org.apache.doris.kafka.connector.exception.CopyLoadException;
 import org.apache.doris.kafka.connector.metrics.DorisConnectMonitor;
 import org.apache.doris.kafka.connector.writer.load.CopyLoad;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -67,22 +66,14 @@ public class TestCopyIntoWriter {
         dorisOptions = new DorisOptions((Map) props);
     }
 
-    @Test(expected = CopyLoadException.class)
+    @Test
     public void fetchOffset() {
-        DorisConnectMonitor dorisConnectMonitor = mock(DorisConnectMonitor.class);
-        dorisWriter =
-                new CopyIntoWriter(
-                        "test5",
-                        0,
-                        dorisOptions,
-                        new JdbcConnectionProvider(dorisOptions),
-                        dorisConnectMonitor);
+        dorisWriter = mockCopyIntoWriter(new String[] {});
         dorisWriter.fetchOffset();
-        Assert.assertEquals(-1l, dorisWriter.getOffsetPersistedInDoris().longValue());
+        Assert.assertEquals(-1, dorisWriter.getOffsetPersistedInDoris().longValue());
     }
 
-    @Test
-    public void fetchOffsetTest() {
+    private CopyIntoWriter mockCopyIntoWriter(String[] listLoadFiles) {
         DorisConnectMonitor dorisConnectMonitor = mock(DorisConnectMonitor.class);
         CopyIntoWriter copyIntoWriter =
                 spy(
@@ -93,7 +84,12 @@ public class TestCopyIntoWriter {
                                 new JdbcConnectionProvider(dorisOptions),
                                 dorisConnectMonitor));
         doReturn(Arrays.asList(listLoadFiles)).when(copyIntoWriter).listLoadFiles();
-        dorisWriter = copyIntoWriter;
+        return copyIntoWriter;
+    }
+
+    @Test
+    public void fetchOffsetTest() {
+        dorisWriter = mockCopyIntoWriter(listLoadFiles);
         dorisWriter.fetchOffset();
         System.out.println(dorisWriter.getOffsetPersistedInDoris().longValue());
         Assert.assertEquals(168172036, dorisWriter.getOffsetPersistedInDoris().longValue());

--- a/src/test/java/org/apache/doris/kafka/connector/writer/TestCopyIntoWriter.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/TestCopyIntoWriter.java
@@ -70,7 +70,7 @@ public class TestCopyIntoWriter {
     public void fetchOffset() {
         dorisWriter = mockCopyIntoWriter(new String[] {});
         dorisWriter.fetchOffset();
-        Assert.assertEquals(-1, dorisWriter.getOffsetPersistedInDoris().longValue());
+        Assert.assertEquals(-1l, dorisWriter.getOffsetPersistedInDoris().longValue());
     }
 
     private CopyIntoWriter mockCopyIntoWriter(String[] listLoadFiles) {

--- a/src/test/java/org/apache/doris/kafka/connector/writer/TestStreamLoadWriter.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/TestStreamLoadWriter.java
@@ -36,7 +36,6 @@ import java.util.Properties;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
 import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
 import org.apache.doris.kafka.connector.connection.JdbcConnectionProvider;
-import org.apache.doris.kafka.connector.exception.StreamLoadException;
 import org.apache.doris.kafka.connector.metrics.DorisConnectMonitor;
 import org.apache.doris.kafka.connector.writer.commit.DorisCommittable;
 import org.apache.doris.kafka.connector.writer.load.DorisStreamLoad;
@@ -82,22 +81,14 @@ public class TestStreamLoadWriter {
                 "VISIBLE");
     }
 
-    @Test(expected = StreamLoadException.class)
+    @Test
     public void fetchOffset() {
-        DorisConnectMonitor dorisConnectMonitor = mock(DorisConnectMonitor.class);
-        dorisWriter =
-                new StreamLoadWriter(
-                        "avro-complex10",
-                        2,
-                        dorisOptions,
-                        new JdbcConnectionProvider(dorisOptions),
-                        dorisConnectMonitor);
+        dorisWriter = mockStreamLoadWriter(new HashMap<>());
         dorisWriter.fetchOffset();
         Assert.assertEquals(-1l, dorisWriter.getOffsetPersistedInDoris().longValue());
     }
 
-    @Test
-    public void fetchOffsetTest() {
+    private StreamLoadWriter mockStreamLoadWriter(Map<String, String> label2Status) {
         DorisConnectMonitor dorisConnectMonitor = mock(DorisConnectMonitor.class);
         StreamLoadWriter streamLoadWriter =
                 spy(
@@ -109,8 +100,12 @@ public class TestStreamLoadWriter {
                                 dorisConnectMonitor));
 
         doReturn(label2Status).when(streamLoadWriter).fetchLabel2Status();
-        dorisWriter = streamLoadWriter;
+        return streamLoadWriter;
+    }
 
+    @Test
+    public void fetchOffsetTest() {
+        dorisWriter = mockStreamLoadWriter(label2Status);
         dorisWriter.fetchOffset();
         System.out.println(dorisWriter.getOffsetPersistedInDoris().longValue());
         Assert.assertEquals(832, dorisWriter.getOffsetPersistedInDoris().longValue());


### PR DESCRIPTION
It turns out that the `fetchOffset()` single test of `TestCopyIntoWriter` and `TestStreamLoadWriter` is running. Since jdbc is actually called to obtain the remote offset, the running time of the single test is particularly high.