### PR TITLE
[improve] Stream load supports writing data from one topic to multipl…

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/writer/load/DorisStreamLoad.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/load/DorisStreamLoad.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
 import org.apache.doris.kafka.connector.exception.StreamLoadException;
 import org.apache.doris.kafka.connector.model.KafkaRespContent;
@@ -56,14 +57,18 @@ public class DorisStreamLoad extends DataLoad {
     private final boolean enableGroupCommit;
 
     public DorisStreamLoad(BackendUtils backendUtils, DorisOptions dorisOptions, String topic) {
+        this.topic = topic;
         this.database = dorisOptions.getDatabase();
         this.table = dorisOptions.getTopicMapTable(topic);
+        if (StringUtils.isEmpty(table)) {
+            // The mapping of topic and table is not defined
+            this.table = this.topic;
+        }
         this.user = dorisOptions.getUser();
         this.password = dorisOptions.getPassword();
         this.loadUrl = String.format(LOAD_URL_PATTERN, hostPort, database, table);
         this.dorisOptions = dorisOptions;
         this.backendUtils = backendUtils;
-        this.topic = topic;
         this.enableGroupCommit = dorisOptions.enableGroupCommit();
     }
 


### PR DESCRIPTION
### it supports writing data from one kafka topic to multiple tables in doris.
When using `stream load` to write data, If the table cannot be found based on the topic in the `"doris.topic2table.map" `configuration, use the topic name as the table name.
 Combining transforms: `io.confluent.connect.transforms.ExtractTopic`, extract data from a message and use it as the topic name. can write data in one topic to multiple tables in doris.