### PR TITLE
add log for record offset is smaller than processedOffset

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/writer/DorisWriter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/DorisWriter.java
@@ -135,6 +135,12 @@ public abstract class DorisWriter {
             if (tmpBuff != null) {
                 flush(tmpBuff);
             }
+        } else {
+            LOG.warn(
+                    "The record offset is smaller than processedOffset. recordOffset={}, offsetPersistedInDoris={}, processedOffset={}",
+                    record.kafkaOffset(),
+                    offsetPersistedInDoris.get(),
+                    processedOffset.get());
         }
     }
 


### PR DESCRIPTION
If the data has been written to doris, the data will no longer be written to avoid repeated consumption. Add logs here to facilitate troubleshooting