### PR TITLE
[Improve] check topic mutating SMTs

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/DorisSinkTask.java
+++ b/src/main/java/org/apache/doris/kafka/connector/DorisSinkTask.java
@@ -55,7 +55,7 @@ public class DorisSinkTask extends SinkTask {
         LOG.info("kafka doris sink task start with {}", parsedConfig);
         this.options = new DorisOptions(parsedConfig);
         this.remainingRetries = options.getMaxRetries();
-        this.sink = DorisSinkServiceFactory.getDorisSinkService(parsedConfig);
+        this.sink = DorisSinkServiceFactory.getDorisSinkService(parsedConfig, context);
     }
 
     /**

--- a/src/main/java/org/apache/doris/kafka/connector/service/DorisSinkServiceFactory.java
+++ b/src/main/java/org/apache/doris/kafka/connector/service/DorisSinkServiceFactory.java
@@ -20,11 +20,13 @@
 package org.apache.doris.kafka.connector.service;
 
 import java.util.Map;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 
 /** A factory to create {@link DorisSinkService} */
 public class DorisSinkServiceFactory {
 
-    public static DorisSinkService getDorisSinkService(Map<String, String> connectorConfig) {
-        return new DorisDefaultSinkService(connectorConfig);
+    public static DorisSinkService getDorisSinkService(
+            Map<String, String> connectorConfig, SinkTaskContext context) {
+        return new DorisDefaultSinkService(connectorConfig, context);
     }
 }

--- a/src/test/java/org/apache/doris/kafka/connector/e2e/kafka/KafkaContainerService.java
+++ b/src/test/java/org/apache/doris/kafka/connector/e2e/kafka/KafkaContainerService.java
@@ -37,5 +37,7 @@ public interface KafkaContainerService {
 
     void deleteKafkaConnector(String name);
 
+    String getConnectorTaskStatus(String name);
+
     void close();
 }

--- a/src/test/java/org/apache/doris/kafka/connector/service/TestDorisSinkService.java
+++ b/src/test/java/org/apache/doris/kafka/connector/service/TestDorisSinkService.java
@@ -19,6 +19,10 @@
 
 package org.apache.doris.kafka.connector.service;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -26,12 +30,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +60,11 @@ public class TestDorisSinkService {
         props.put("task_id", "1");
         props.put("name", "sink-connector-test");
         props.put("record.tablename.field", "table_name");
-        dorisDefaultSinkService = new DorisDefaultSinkService((Map) props);
+        props.put("enable.2pc", "false");
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        TopicPartition assignedTp = new TopicPartition("expected-topic", 0);
+        when(context.assignment()).thenReturn(Sets.newHashSet(assignedTp));
+        dorisDefaultSinkService = new DorisDefaultSinkService((Map) props, context);
         jsonConverter.configure(new HashMap<>(), false);
     }
 
@@ -131,5 +142,33 @@ public class TestDorisSinkService {
                         3);
         Assert.assertEquals(
                 "test_kafka_tbl", dorisDefaultSinkService.getSinkDorisTableName(record5));
+    }
+
+    @Test
+    public void testCheckTopicMutating() {
+        SinkRecord record1 =
+                new SinkRecord(
+                        "expected-topic",
+                        0,
+                        Schema.OPTIONAL_STRING_SCHEMA,
+                        "key",
+                        Schema.OPTIONAL_STRING_SCHEMA,
+                        "val",
+                        1);
+        SinkRecord record2 =
+                new SinkRecord(
+                        "mutated-topic",
+                        0,
+                        Schema.OPTIONAL_STRING_SCHEMA,
+                        "key",
+                        Schema.OPTIONAL_STRING_SCHEMA,
+                        "val",
+                        1);
+        dorisDefaultSinkService.checkTopicMutating(record1);
+
+        Assert.assertThrows(
+                "Unexpected topic name: [mutated_topic] that doesn't match assigned partitions. Connector doesn't support topic mutating SMTs.",
+                ConnectException.class,
+                () -> dorisDefaultSinkService.checkTopicMutating(record2));
     }
 }

--- a/src/test/java/org/apache/doris/kafka/connector/service/TestDorisSinkService.java
+++ b/src/test/java/org/apache/doris/kafka/connector/service/TestDorisSinkService.java
@@ -60,7 +60,6 @@ public class TestDorisSinkService {
         props.put("task_id", "1");
         props.put("name", "sink-connector-test");
         props.put("record.tablename.field", "table_name");
-        props.put("enable.2pc", "false");
         SinkTaskContext context = mock(SinkTaskContext.class);
         TopicPartition assignedTp = new TopicPartition("expected-topic", 0);
         when(context.assignment()).thenReturn(Sets.newHashSet(assignedTp));

--- a/src/test/resources/e2e/transforms/regex_router_transforms.json
+++ b/src/test/resources/e2e/transforms/regex_router_transforms.json
@@ -1,0 +1,26 @@
+{
+  "name":"regex_router_transforms_connector",
+  "config":{
+    "connector.class":"org.apache.doris.kafka.connector.DorisSinkConnector",
+    "topics":"p-regex_router_transform_msg",
+    "tasks.max":"1",
+    "doris.topic2table.map": "p-regex_router_transform_msg:regex_router_transform_msg,regex_router_transform_msg:regex_router_transform_msg",
+    "buffer.count.records":"2",
+    "buffer.flush.time":"11",
+    "buffer.size.bytes":"10000000",
+    "doris.urls":"127.0.0.1",
+    "doris.user":"root",
+    "doris.password":"",
+    "doris.http.port":"8030",
+    "doris.query.port":"9030",
+    "doris.database":"transforms_msg",
+    "load.model":"stream_load",
+    "transforms": "dropPrefix",
+    "transforms.dropPrefix.type": "org.apache.kafka.connect.transforms.RegexRouter",
+    "transforms.dropPrefix.regex": "p-(.*)",
+    "transforms.dropPrefix.replacement": "$1",
+    "key.converter":"org.apache.kafka.connect.storage.StringConverter",
+    "value.converter":"org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false"
+  }
+}

--- a/src/test/resources/e2e/transforms/regex_router_transforms.sql
+++ b/src/test/resources/e2e/transforms/regex_router_transforms.sql
@@ -1,0 +1,12 @@
+-- Please note that the database here should be consistent with doris.database in the file where the connector is registered.
+CREATE TABLE transforms_msg.regex_router_transform_msg (
+  id INT NULL,
+  col1 VARCHAR(20) NULL,
+  col2 varchar(20) NULL
+) ENGINE=OLAP
+UNIQUE KEY(`id`)
+COMMENT 'OLAP'
+DISTRIBUTED BY HASH(`id`) BUCKETS AUTO
+PROPERTIES (
+"replication_allocation" = "tag.location.default: 1"
+);


### PR DESCRIPTION
Currentlly, if using `io.confluent.connect.transforms.ExtractTopic` or `org.apache.kafka.connect.transforms.RegexRouter` or other transforms that mutate topic, **`doris-kafka-connector` will not successfully submit the consumer offset.** because in `org.apache.kafka.connect.sink.SinkTask#preCommit`, the topic corresponds to the original topic before applying any transformations. If the connector is restarted, it will be consumed repeatedly. 

More seriously, by default, **`two_phase_commit` is enabled, data will not be written to doris** because transactions were not successfully committed in `org.apache.kafka.connect.sink.SinkTask#preCommit`. But at this point, both the connector and task are in a normal RUNNING state, and the user is not aware of this abnormal situation. 

So, I think it would be better to throw an exception directly in this situation

For example, for the following configured connector:

> {
>   "name":"test_connector",
>   "config":{
>         "connector.class":"org.apache.doris.kafka.connector.DorisSinkConnector",
>         "topics":"original_topic",
>         "tasks.max":"1",
>         "doris.topic2table.map": "original_topic:test_table",
>         "buffer.count.records":"2",
>         "buffer.flush.time":"11",
>         "buffer.size.bytes":"10000000",
>         "doris.urls":"127.0.0.1",
>         "doris.user":"root",
>         "doris.password":"",
>         "doris.http.port":"8030",
>         "doris.query.port":"9030",
>         "doris.database":"transforms_msg",
>         "load.model":"stream_load",
>         "transforms": "AddPrefix",
> 	    "transforms.AddPrefix.type": "org.apache.kafka.connect.transforms.RegexRouter",
> 	    "transforms.AddPrefix.regex": ".*",
> 	    "transforms.AddPrefix.replacement": "transformed_$0"
>   }
> }

the status of task is  FAILED , and errors will occur when consuming data：
`Unexpected topic name: [transformed_original_topic] that doesn't match assigned partitions. Connector doesn't support topic mutating SMTs. `