### PR TITLE
[improve] update config default value and add combine flush mode

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/DorisSinkTask.java
+++ b/src/main/java/org/apache/doris/kafka/connector/DorisSinkTask.java
@@ -55,7 +55,7 @@ public class DorisSinkTask extends SinkTask {
         LOG.info("kafka doris sink task start with {}", parsedConfig);
         this.options = new DorisOptions(parsedConfig);
         this.remainingRetries = options.getMaxRetries();
-        this.sink = DorisSinkServiceFactory.getDorisSinkService(parsedConfig, context);
+        this.sink = DorisSinkServiceFactory.getDorisSinkService(parsedConfig, context, options);
     }
 
     /**

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
@@ -101,14 +101,21 @@ public class DorisOptions {
                         config.get(DorisSinkConnectorConfig.TOPICS_TABLES_MAP));
         this.tableNameField = config.get(DorisSinkConnectorConfig.RECORD_TABLE_NAME_FIELD);
 
-        if (config.containsKey(DorisSinkConnectorConfig.ENABLE_2PC)) {
-            if (Boolean.parseBoolean(config.get(DorisSinkConnectorConfig.ENABLE_2PC))) {
-                this.enable2PC = true;
-                this.force2PC = true;
-            } else {
-                this.enable2PC = false;
+        if (enableCombineFlush) {
+            LOG.info("Enable combine flush, set 2pc to false.");
+            this.enable2PC = false;
+            this.force2PC = false;
+        } else {
+            if (config.containsKey(DorisSinkConnectorConfig.ENABLE_2PC)) {
+                if (Boolean.parseBoolean(config.get(DorisSinkConnectorConfig.ENABLE_2PC))) {
+                    this.enable2PC = true;
+                    this.force2PC = true;
+                } else {
+                    this.enable2PC = false;
+                }
             }
         }
+
         this.enableCustomJMX = Boolean.parseBoolean(config.get(DorisSinkConnectorConfig.JMX_OPT));
         this.enableDelete =
                 Boolean.parseBoolean(config.get(DorisSinkConnectorConfig.ENABLE_DELETE));

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
@@ -70,6 +70,7 @@ public class DorisOptions {
     private final int maxRetries;
     private final int retryIntervalMs;
     private final BehaviorOnNullValues behaviorOnNullValues;
+    private final boolean enableCombineFlush;
 
     public DorisOptions(Map<String, String> config) {
         this.name = config.get(DorisSinkConnectorConfig.NAME);
@@ -84,6 +85,8 @@ public class DorisOptions {
         this.loadModel = LoadModel.of(config.get(DorisSinkConnectorConfig.LOAD_MODEL));
         this.deliveryGuarantee =
                 DeliveryGuarantee.of(config.get(DorisSinkConnectorConfig.DELIVERY_GUARANTEE));
+        this.enableCombineFlush =
+                Boolean.valueOf(config.get(DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH));
         this.converterMode = ConverterMode.of(config.get(DorisSinkConnectorConfig.CONVERTER_MODE));
         this.schemaEvolutionMode =
                 SchemaEvolutionMode.of(
@@ -349,5 +352,9 @@ public class DorisOptions {
 
     public BehaviorOnNullValues getBehaviorOnNullValues() {
         return behaviorOnNullValues;
+    }
+
+    public boolean isEnableCombineFlush() {
+        return enableCombineFlush;
     }
 }

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
@@ -48,16 +48,16 @@ public class DorisSinkConnectorConfig {
     // Connector config
     private static final String CONNECTOR_CONFIG = "Connector Config";
     public static final String BUFFER_COUNT_RECORDS = "buffer.count.records";
-    public static final long BUFFER_COUNT_RECORDS_DEFAULT = 10000;
+    public static final long BUFFER_COUNT_RECORDS_DEFAULT = 50000;
     public static final String BUFFER_SIZE_BYTES = "buffer.size.bytes";
-    public static final long BUFFER_SIZE_BYTES_DEFAULT = 5000000;
+    public static final long BUFFER_SIZE_BYTES_DEFAULT = 100 * 1024 * 1024;
     public static final long BUFFER_SIZE_BYTES_MIN = 1;
     public static final String TOPICS_TABLES_MAP = "doris.topic2table.map";
     public static final String RECORD_TABLE_NAME_FIELD = "record.tablename.field";
     public static final String LABEL_PREFIX = "label.prefix";
 
     // Time in seconds
-    public static final long BUFFER_FLUSH_TIME_SEC_MIN = 10;
+    public static final long BUFFER_FLUSH_TIME_SEC_MIN = 1;
     public static final long BUFFER_FLUSH_TIME_SEC_DEFAULT = 120;
     public static final String BUFFER_FLUSH_TIME_SEC = "buffer.flush.time";
 

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
@@ -81,6 +81,8 @@ public class DorisSinkConnectorConfig {
     public static final String AUTO_REDIRECT = "auto.redirect";
     public static final String DELIVERY_GUARANTEE = "delivery.guarantee";
     public static final String DELIVERY_GUARANTEE_DEFAULT = DeliveryGuarantee.AT_LEAST_ONCE.name();
+    public static final String ENABLE_COMBINE_FLUSH = "enable.combine.flush";
+    public static final String ENABLE_COMBINE_FLUSH_DEFAULT = "false";
     public static final String CONVERTER_MODE = "converter.mode";
     public static final String CONVERT_MODE_DEFAULT = ConverterMode.NORMAL.getName();
 
@@ -130,6 +132,7 @@ public class DorisSinkConnectorConfig {
         setFieldToDefaultValues(
                 config, RETRY_INTERVAL_MS, String.valueOf(RETRY_INTERVAL_MS_DEFAULT));
         setFieldToDefaultValues(config, BEHAVIOR_ON_NULL_VALUES, BEHAVIOR_ON_NULL_VALUES_DEFAULT);
+        setFieldToDefaultValues(config, ENABLE_COMBINE_FLUSH, ENABLE_COMBINE_FLUSH_DEFAULT);
     }
 
     public static Map<String, String> convertToLowercase(Map<String, String> config) {

--- a/src/main/java/org/apache/doris/kafka/connector/service/DorisCombinedSinkService.java
+++ b/src/main/java/org/apache/doris/kafka/connector/service/DorisCombinedSinkService.java
@@ -56,6 +56,7 @@ public class DorisCombinedSinkService extends DorisDefaultSinkService {
             LOG.info("already start task with key {}", writerKey);
         } else {
             String topic = topicPartition.topic();
+
             // Only by topic
             int partition = -1;
             DorisWriter dorisWriter =
@@ -79,10 +80,9 @@ public class DorisCombinedSinkService extends DorisDefaultSinkService {
 
             String topic = record.topic();
             int partition = record.kafkaPartition();
-            if (!topicPartitionOffset.containsKey(topic)) {
-                topicPartitionOffset.put(topic, new HashMap<>());
-            }
-            topicPartitionOffset.get(topic).put(partition, record.kafkaOffset());
+            topicPartitionOffset
+                    .computeIfAbsent(topic, k -> new HashMap<>())
+                    .put(partition, record.kafkaOffset());
             // Might happen a count of record based flushing，buffer
             insert(record);
         }

--- a/src/main/java/org/apache/doris/kafka/connector/service/DorisDefaultSinkService.java
+++ b/src/main/java/org/apache/doris/kafka/connector/service/DorisDefaultSinkService.java
@@ -64,13 +64,13 @@ import org.slf4j.LoggerFactory;
 public class DorisDefaultSinkService implements DorisSinkService {
     private static final Logger LOG = LoggerFactory.getLogger(DorisDefaultSinkService.class);
 
-    private final ConnectionProvider conn;
-    private final Map<String, DorisWriter> writer;
-    private final DorisOptions dorisOptions;
-    private final MetricsJmxReporter metricsJmxReporter;
-    private final DorisConnectMonitor connectMonitor;
-    private final ObjectMapper objectMapper;
-    private final SinkTaskContext context;
+    protected final ConnectionProvider conn;
+    protected final Map<String, DorisWriter> writer;
+    protected final DorisOptions dorisOptions;
+    protected final MetricsJmxReporter metricsJmxReporter;
+    protected final DorisConnectMonitor connectMonitor;
+    protected final ObjectMapper objectMapper;
+    protected final SinkTaskContext context;
 
     DorisDefaultSinkService(Map<String, String> config, SinkTaskContext context) {
         this.dorisOptions = new DorisOptions(config);

--- a/src/main/java/org/apache/doris/kafka/connector/service/DorisDefaultSinkService.java
+++ b/src/main/java/org/apache/doris/kafka/connector/service/DorisDefaultSinkService.java
@@ -142,6 +142,7 @@ public class DorisDefaultSinkService implements DorisSinkService {
         for (DorisWriter writer : writer.values()) {
             // Time based flushing
             if (writer.shouldFlush()) {
+                LOG.info("trigger flush by time.");
                 writer.flushBuffer();
             }
         }

--- a/src/main/java/org/apache/doris/kafka/connector/service/DorisSinkServiceFactory.java
+++ b/src/main/java/org/apache/doris/kafka/connector/service/DorisSinkServiceFactory.java
@@ -20,13 +20,18 @@
 package org.apache.doris.kafka.connector.service;
 
 import java.util.Map;
+import org.apache.doris.kafka.connector.cfg.DorisOptions;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 
 /** A factory to create {@link DorisSinkService} */
 public class DorisSinkServiceFactory {
 
     public static DorisSinkService getDorisSinkService(
-            Map<String, String> connectorConfig, SinkTaskContext context) {
-        return new DorisDefaultSinkService(connectorConfig, context);
+            Map<String, String> connectorConfig, SinkTaskContext context, DorisOptions options) {
+        if (options.isEnableCombineFlush()) {
+            return new DorisCombinedSinkService(connectorConfig, context);
+        } else {
+            return new DorisDefaultSinkService(connectorConfig, context);
+        }
     }
 }

--- a/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
@@ -144,7 +144,7 @@ public class ConfigCheckUtils {
                 || isIllegalRange(
                         bufferFlushTime, DorisSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN)) {
             LOG.error(
-                    "{} cannot be empty or not a number or less than 10.",
+                    "{} cannot be empty or not a number or less than 1.",
                     DorisSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
             configIsValid = false;
         }

--- a/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
@@ -162,8 +162,29 @@ public class ConfigCheckUtils {
         if (!validateEnumInstances(deliveryGuarantee, DeliveryGuarantee.instances())) {
             LOG.error(
                     "The value of {} is an illegal parameter of {}.",
-                    loadModel,
+                    deliveryGuarantee,
                     DorisSinkConnectorConfig.DELIVERY_GUARANTEE);
+            configIsValid = false;
+        }
+
+        String enableCombineFlush = config.get(DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH);
+        if (!validateEnumInstances(enableCombineFlush, new String[] {"true", "false"})) {
+            LOG.error(
+                    "The value of {} is an illegal parameter of {}.",
+                    enableCombineFlush,
+                    DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH);
+            configIsValid = false;
+        }
+
+        if (configIsValid
+                && Boolean.parseBoolean(enableCombineFlush)
+                && DeliveryGuarantee.EXACTLY_ONCE.name().equalsIgnoreCase(deliveryGuarantee)) {
+            LOG.error(
+                    "The value of {} is not supported set {} when {} is set to {}.",
+                    DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH,
+                    enableCombineFlush,
+                    DorisSinkConnectorConfig.DELIVERY_GUARANTEE,
+                    DeliveryGuarantee.EXACTLY_ONCE.name());
             configIsValid = false;
         }
 

--- a/src/main/java/org/apache/doris/kafka/connector/writer/DorisWriter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/DorisWriter.java
@@ -116,8 +116,11 @@ public abstract class DorisWriter {
 
     protected void insertRecord(final SinkRecord record) {
         // discard the record if the record offset is smaller or equal to server side offset
-        if (record.kafkaOffset() > this.offsetPersistedInDoris.get()
-                && record.kafkaOffset() > processedOffset.get()) {
+        // when enable.combine.flush=true, No verification is required because the offsets of
+        // multiple partitions cannot be compared.
+        if (dorisOptions.isEnableCombineFlush()
+                || (record.kafkaOffset() > this.offsetPersistedInDoris.get()
+                        && record.kafkaOffset() > processedOffset.get())) {
             SinkRecord dorisRecord = record;
             RecordBuffer tmpBuff = null;
 

--- a/src/main/java/org/apache/doris/kafka/connector/writer/DorisWriter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/DorisWriter.java
@@ -130,6 +130,10 @@ public abstract class DorisWriter {
             }
 
             if (tmpBuff != null) {
+                LOG.info(
+                        "trigger flush by buffer size or count, buffer size: {}, num of records: {}",
+                        tmpBuff.getBufferSizeBytes(),
+                        tmpBuff.getNumOfRecords());
                 flush(tmpBuff);
             }
             processedOffset.set(dorisRecord.kafkaOffset());

--- a/src/test/java/org/apache/doris/kafka/connector/e2e/sink/stringconverter/StringMsgE2ETest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/e2e/sink/stringconverter/StringMsgE2ETest.java
@@ -417,6 +417,37 @@ public class StringMsgE2ETest extends AbstractStringE2ESinkTest {
         Assert.assertEquals(12, age);
     }
 
+    @Test
+    public void testCombineFlush2PC() throws IOException, InterruptedException, SQLException {
+        initialize("src/test/resources/e2e/string_converter/combine_flush_connector_2pc.json");
+        Thread.sleep(5000);
+        String topic = "combine_test_2pc";
+        String msg = "{\"id\":1,\"name\":\"zhangsan\",\"age\":12}";
+
+        produceMsg2Kafka(topic, msg);
+        String tableSql =
+                loadContent("src/test/resources/e2e/string_converter/combine_flush_tab_2pc.sql");
+        createTable(tableSql);
+        kafkaContainerService.registerKafkaConnector(connectorName, jsonMsgConnectorContent);
+
+        String table = dorisOptions.getTopicMapTable(topic);
+        Statement statement = getJdbcConnection().createStatement();
+        String querySql = "select * from " + database + "." + table;
+        LOG.info("start to query result from doris. sql={}", querySql);
+        ResultSet resultSet = statement.executeQuery(querySql);
+
+        Assert.assertTrue(resultSet.next());
+
+        int id = resultSet.getInt("id");
+        String name = resultSet.getString("name");
+        int age = resultSet.getInt("age");
+        LOG.info("Query result is id={}, name={}, age={}", id, name, age);
+
+        Assert.assertEquals(1, id);
+        Assert.assertEquals("zhangsan", name);
+        Assert.assertEquals(12, age);
+    }
+
     @AfterClass
     public static void closeInstance() {
         kafkaContainerService.deleteKafkaConnector(connectorName);

--- a/src/test/java/org/apache/doris/kafka/connector/e2e/sink/stringconverter/StringMsgE2ETest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/e2e/sink/stringconverter/StringMsgE2ETest.java
@@ -386,6 +386,37 @@ public class StringMsgE2ETest extends AbstractStringE2ESinkTest {
         checkResult(expected, query1, 3);
     }
 
+    @Test
+    public void testCombineFlush() throws IOException, InterruptedException, SQLException {
+        initialize("src/test/resources/e2e/string_converter/combine_flush_connector.json");
+        Thread.sleep(5000);
+        String topic = "combine_test";
+        String msg = "{\"id\":1,\"name\":\"zhangsan\",\"age\":12}";
+
+        produceMsg2Kafka(topic, msg);
+        String tableSql =
+                loadContent("src/test/resources/e2e/string_converter/combine_flush_tab.sql");
+        createTable(tableSql);
+        kafkaContainerService.registerKafkaConnector(connectorName, jsonMsgConnectorContent);
+
+        String table = dorisOptions.getTopicMapTable(topic);
+        Statement statement = getJdbcConnection().createStatement();
+        String querySql = "select * from " + database + "." + table;
+        LOG.info("start to query result from doris. sql={}", querySql);
+        ResultSet resultSet = statement.executeQuery(querySql);
+
+        Assert.assertTrue(resultSet.next());
+
+        int id = resultSet.getInt("id");
+        String name = resultSet.getString("name");
+        int age = resultSet.getInt("age");
+        LOG.info("Query result is id={}, name={}, age={}", id, name, age);
+
+        Assert.assertEquals(1, id);
+        Assert.assertEquals("zhangsan", name);
+        Assert.assertEquals(12, age);
+    }
+
     @AfterClass
     public static void closeInstance() {
         kafkaContainerService.deleteKafkaConnector(connectorName);

--- a/src/test/resources/e2e/string_converter/combine_flush_connector.json
+++ b/src/test/resources/e2e/string_converter/combine_flush_connector.json
@@ -1,0 +1,22 @@
+{
+  "name":"combine_flush_connector",
+  "config":{
+    "connector.class":"org.apache.doris.kafka.connector.DorisSinkConnector",
+    "topics":"combine_test",
+    "tasks.max":"1",
+    "doris.topic2table.map": "combine_test:combine_flush_tab",
+    "buffer.count.records":"100",
+    "buffer.flush.time":"1",
+    "buffer.size.bytes":"10000000",
+    "doris.urls":"127.0.0.1",
+    "doris.user":"root",
+    "doris.password":"",
+    "doris.http.port":"8030",
+    "doris.query.port":"9030",
+    "doris.database":"combine_flush",
+    "load.model":"stream_load",
+    "enable.combine.flush":"true",
+    "key.converter":"org.apache.kafka.connect.storage.StringConverter",
+    "value.converter":"org.apache.kafka.connect.storage.StringConverter"
+  }
+}

--- a/src/test/resources/e2e/string_converter/combine_flush_connector_2pc.json
+++ b/src/test/resources/e2e/string_converter/combine_flush_connector_2pc.json
@@ -1,0 +1,23 @@
+{
+  "name":"combine_flush_connector_2pc",
+  "config":{
+    "connector.class":"org.apache.doris.kafka.connector.DorisSinkConnector",
+    "topics":"combine_test_2pc",
+    "tasks.max":"1",
+    "doris.topic2table.map": "combine_test_2pc:combine_flush_tab_2pc",
+    "buffer.count.records":"100",
+    "buffer.flush.time":"1",
+    "buffer.size.bytes":"10000000",
+    "doris.urls":"127.0.0.1",
+    "doris.user":"root",
+    "doris.password":"",
+    "doris.http.port":"8030",
+    "doris.query.port":"9030",
+    "doris.database":"combine_flush_2pc",
+    "load.model":"stream_load",
+    "enable.combine.flush":"true",
+    "enable.2pc": "true",
+    "key.converter":"org.apache.kafka.connect.storage.StringConverter",
+    "value.converter":"org.apache.kafka.connect.storage.StringConverter"
+  }
+}

--- a/src/test/resources/e2e/string_converter/combine_flush_tab.sql
+++ b/src/test/resources/e2e/string_converter/combine_flush_tab.sql
@@ -1,0 +1,12 @@
+-- Please note that the database here should be consistent with doris.database in the file where the connector is registered.
+CREATE TABLE combine_flush.combine_flush_tab (
+  id INT NULL,
+  name VARCHAR(100) NULL,
+  age INT NULL
+) ENGINE=OLAP
+UNIQUE KEY(`id`)
+COMMENT 'OLAP'
+DISTRIBUTED BY HASH(`id`) BUCKETS AUTO
+PROPERTIES (
+"replication_allocation" = "tag.location.default: 1"
+);

--- a/src/test/resources/e2e/string_converter/combine_flush_tab_2pc.sql
+++ b/src/test/resources/e2e/string_converter/combine_flush_tab_2pc.sql
@@ -1,0 +1,12 @@
+-- Please note that the database here should be consistent with doris.database in the file where the connector is registered.
+CREATE TABLE combine_flush_2pc.combine_flush_tab_2pc (
+  id INT NULL,
+  name VARCHAR(100) NULL,
+  age INT NULL
+) ENGINE=OLAP
+UNIQUE KEY(`id`)
+COMMENT 'OLAP'
+DISTRIBUTED BY HASH(`id`) BUCKETS AUTO
+PROPERTIES (
+"replication_allocation" = "tag.location.default: 1"
+);


### PR DESCRIPTION
Currently, during the write process, data is written based on partitions, and the label will be concatenated with the partition ID. This is to ensure exactly-once semantics. However, when there are a large number of partitions, such as 100, even with very small amounts of data, 100 streamload operations will be initiated each time. 

For unique tables, idempotency can be leveraged to achieve exactly-once semantics, so during the write process, all partitions can be merged together for writing.
 The configuration is set to  enable.combine.flush=true .​