### PR TITLE
[fix] fix the check of 'topic2table' configuration

### DIFF
--- a/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
@@ -83,8 +83,8 @@ public class ConfigCheckUtils {
             configIsValid = false;
         }
 
-        if (config.containsKey(DorisSinkConnectorConfig.TOPICS_TABLES_MAP)
-                && parseTopicToTableMap(config.get(DorisSinkConnectorConfig.TOPICS_TABLES_MAP))
+        if (!config.containsKey(DorisSinkConnectorConfig.TOPICS_TABLES_MAP)
+                || parseTopicToTableMap(config.get(DorisSinkConnectorConfig.TOPICS_TABLES_MAP))
                         == null) {
             LOG.error("{} is empty or invalid.", DorisSinkConnectorConfig.TOPICS_TABLES_MAP);
             configIsValid = false;

--- a/src/test/java/org/apache/doris/kafka/connector/cfg/TestDorisSinkConnectorConfig.java
+++ b/src/test/java/org/apache/doris/kafka/connector/cfg/TestDorisSinkConnectorConfig.java
@@ -45,6 +45,7 @@ public class TestDorisSinkConnectorConfig {
         config.put(DorisSinkConnectorConfig.DORIS_PASSWORD, "password");
 
         config.put(DorisSinkConnectorConfig.DORIS_DATABASE, "testDatabase");
+        config.put(DorisSinkConnectorConfig.TOPICS_TABLES_MAP, "topic1:table1,topic2:table2");
         config.put(
                 DorisSinkConnectorConfig.BUFFER_COUNT_RECORDS,
                 DorisSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT + "");
@@ -61,6 +62,13 @@ public class TestDorisSinkConnectorConfig {
     @Test
     public void testConfig() {
         Map<String, String> config = getConfig();
+        ConfigCheckUtils.validateConfig(config);
+    }
+
+    @Test(expected = DorisException.class)
+    public void testEmptyTopic2MapConfig() {
+        Map<String, String> config = getConfig();
+        config.remove(DorisSinkConnectorConfig.TOPICS_TABLES_MAP);
         ConfigCheckUtils.validateConfig(config);
     }
 


### PR DESCRIPTION
Currently, the configuration of 'doris.topic2table.map' is required, but it is not checked when start the connector.
relate issue: #82 