### PR TITLE
[fix] Disable gzip compression in schema evolution e2e test

### DIFF
--- a/src/test/resources/e2e/string_converter/schema_evolution_connector.json
+++ b/src/test/resources/e2e/string_converter/schema_evolution_connector.json
@@ -20,6 +20,7 @@
     "enable.2pc": "false",
     "load.model":"stream_load",
     "key.converter":"org.apache.kafka.connect.json.JsonConverter",
-    "value.converter":"org.apache.kafka.connect.json.JsonConverter"
+    "value.converter":"org.apache.kafka.connect.json.JsonConverter",
+    "sink.properties.compress_type":""
   }
 }


### PR DESCRIPTION
## Summary
- `schema_evolution_connector.json` was missing `sink.properties.compress_type=""`, causing `testDebeziumSchemaEvolution` to fail with `compress data of JSON format is not supported` error on Doris 2.1
- This was introduced by #95 which enabled gzip compression by default, but the newly added schema evolution config file was not updated

## Test plan
- [ ] CI e2e tests pass, specifically `testDebeziumSchemaEvolution`

🤖 Generated with [Claude Code](https://claude.com/claude-code)