### PR TITLE
[Feature] Support S3 TVF sink mode

### DIFF
--- a/.github/workflows/kafka2doris-e2ecase.yaml
+++ b/.github/workflows/kafka2doris-e2ecase.yaml
@@ -39,6 +39,11 @@ jobs:
           distribution: adopt
           java-version: '8'
 
+      - name: Configure Doris prerequisites
+        run: |
+          sudo sysctl -w vm.max_map_count=2000000
+          sudo swapoff -a
+
       - name: Doris E2E Test
         run: |
           mvn test -Dtest='org.apache.doris.kafka.connector.e2e.**'

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <commons-io.version>2.3</commons-io.version>
         <geometry.version>2.2.0</geometry.version>
         <testcontainers.version>1.17.6</testcontainers.version>
+        <awssdk.version>2.29.52</awssdk.version>
     </properties>
 
     <repositories>
@@ -157,6 +158,26 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql-connector.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${awssdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/apache/doris/kafka/connector/DorisSinkTask.java
+++ b/src/main/java/org/apache/doris/kafka/connector/DorisSinkTask.java
@@ -52,7 +52,7 @@ public class DorisSinkTask extends SinkTask {
      */
     @Override
     public void start(final Map<String, String> parsedConfig) {
-        LOG.info("kafka doris sink task start with {}", parsedConfig);
+        LOG.info("kafka doris sink task starting");
         this.options = new DorisOptions(parsedConfig);
         this.remainingRetries = options.getMaxRetries();
         this.sink = DorisSinkServiceFactory.getDorisSinkService(parsedConfig, context, options);

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisOptions.java
@@ -22,9 +22,12 @@ package org.apache.doris.kafka.connector.cfg;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.doris.kafka.connector.converter.ConverterMode;
 import org.apache.doris.kafka.connector.converter.schema.SchemaEvolutionMode;
@@ -72,6 +75,9 @@ public class DorisOptions {
     private final BehaviorOnNullValues behaviorOnNullValues;
     private final boolean enableCombineFlush;
     private final DorisTlsOptions tlsOptions;
+    private final S3TvfOptions s3TvfOptions;
+    private final List<String> tvfColumns;
+    private final Map<String, String> sessionVariables;
 
     public DorisOptions(Map<String, String> config) {
         this.name = config.get(DorisSinkConnectorConfig.NAME);
@@ -141,7 +147,13 @@ public class DorisOptions {
                     Integer.parseInt(config.get(DorisSinkConnectorConfig.REQUEST_READ_TIMEOUT_MS));
         }
         this.streamLoadProp = getStreamLoadPropFromConfig(config);
-        this.enableGroupCommit = ConfigCheckUtils.validateGroupCommitMode(this);
+        this.s3TvfOptions = buildS3TvfOptions(config);
+        this.tvfColumns = resolveTvfColumns();
+        this.sessionVariables = getSessionVariablesFromConfig(config);
+        this.enableGroupCommit =
+                LoadModel.TVF.equals(loadModel)
+                        ? false
+                        : ConfigCheckUtils.validateGroupCommitMode(this);
         this.maxRetries =
                 Integer.parseInt(
                         config.getOrDefault(
@@ -207,6 +219,66 @@ public class DorisOptions {
         properties.setProperty("read_json_by_line", "true");
         properties.setProperty("compress_type", "gz");
         return properties;
+    }
+
+    private S3TvfOptions buildS3TvfOptions(Map<String, String> config) {
+        if (!LoadModel.TVF.equals(loadModel)) {
+            return null;
+        }
+        return S3TvfOptions.builder()
+                .setEndpoint(config.get(DorisSinkConnectorConfig.SINK_S3_ENDPOINT))
+                .setRegion(config.get(DorisSinkConnectorConfig.SINK_S3_REGION))
+                .setBucket(config.get(DorisSinkConnectorConfig.SINK_S3_BUCKET))
+                .setPrefix(config.get(DorisSinkConnectorConfig.SINK_S3_PREFIX))
+                .setAccessKey(config.get(DorisSinkConnectorConfig.SINK_S3_ACCESS_KEY))
+                .setSecretKey(config.get(DorisSinkConnectorConfig.SINK_S3_SECRET_KEY))
+                .setPathStyleAccess(
+                        Boolean.parseBoolean(
+                                config.getOrDefault(
+                                        DorisSinkConnectorConfig.SINK_S3_PATH_STYLE_ACCESS,
+                                        String.valueOf(
+                                                DorisSinkConnectorConfig
+                                                        .SINK_S3_PATH_STYLE_ACCESS_DEFAULT))))
+                .build();
+    }
+
+    private List<String> resolveTvfColumns() {
+        if (!LoadModel.TVF.equals(loadModel)) {
+            return Collections.emptyList();
+        }
+        return TvfColumnUtils.resolveColumns(streamLoadProp.getProperty("columns"));
+    }
+
+    private Map<String, String> getSessionVariablesFromConfig(Map<String, String> config) {
+        if (!LoadModel.TVF.equals(loadModel)) {
+            return Collections.emptyMap();
+        }
+        Set<String> transportProperties =
+                new HashSet<>(
+                        Arrays.asList(
+                                "format",
+                                "read_json_by_line",
+                                "compress_type",
+                                "columns",
+                                "partial_columns"));
+        Map<String, String> variables = new HashMap<>();
+        for (Map.Entry<String, String> entry : config.entrySet()) {
+            if (!entry.getKey().startsWith(DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX)) {
+                continue;
+            }
+            String name =
+                    entry.getKey()
+                            .substring(DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX.length());
+            if (!transportProperties.contains(name)) {
+                variables.put(name, entry.getValue());
+            }
+        }
+        String partialColumns =
+                config.get(DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX + "partial_columns");
+        if (partialColumns != null) {
+            variables.put("enable_unique_key_partial_update", partialColumns);
+        }
+        return Collections.unmodifiableMap(variables);
     }
 
     public String getName() {
@@ -389,6 +461,18 @@ public class DorisOptions {
 
     public DorisTlsOptions getTlsOptions() {
         return tlsOptions;
+    }
+
+    public S3TvfOptions getS3TvfOptions() {
+        return s3TvfOptions;
+    }
+
+    public List<String> getTvfColumns() {
+        return tvfColumns;
+    }
+
+    public Map<String, String> getSessionVariables() {
+        return sessionVariables;
     }
 
     public BehaviorOnNullValues getBehaviorOnNullValues() {

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/DorisSinkConnectorConfig.java
@@ -63,6 +63,7 @@ public class DorisSinkConnectorConfig {
     public static final String BUFFER_FLUSH_TIME_SEC = "buffer.flush.time";
 
     private static final String DORIS_INFO = "Doris Cluster Info";
+    private static final String TVF_CONFIG = "TVF Config";
 
     // doris config
     public static final String DORIS_URLS = "doris.urls";
@@ -93,6 +94,14 @@ public class DorisSinkConnectorConfig {
     public static final String DELIVERY_GUARANTEE_DEFAULT = DeliveryGuarantee.AT_LEAST_ONCE.name();
     public static final String ENABLE_COMBINE_FLUSH = "enable.combine.flush";
     public static final String ENABLE_COMBINE_FLUSH_DEFAULT = "false";
+    public static final String SINK_S3_ENDPOINT = "sink.s3.endpoint";
+    public static final String SINK_S3_REGION = "sink.s3.region";
+    public static final String SINK_S3_BUCKET = "sink.s3.bucket";
+    public static final String SINK_S3_PREFIX = "sink.s3.prefix";
+    public static final String SINK_S3_ACCESS_KEY = "sink.s3.access-key";
+    public static final String SINK_S3_SECRET_KEY = "sink.s3.secret-key";
+    public static final String SINK_S3_PATH_STYLE_ACCESS = "sink.s3.path-style-access";
+    public static final boolean SINK_S3_PATH_STYLE_ACCESS_DEFAULT = false;
     public static final String CONVERTER_MODE = "converter.mode";
     public static final String CONVERT_MODE_DEFAULT = ConverterMode.NORMAL.getName();
 
@@ -145,6 +154,10 @@ public class DorisSinkConnectorConfig {
                 config, RETRY_INTERVAL_MS, String.valueOf(RETRY_INTERVAL_MS_DEFAULT));
         setFieldToDefaultValues(config, BEHAVIOR_ON_NULL_VALUES, BEHAVIOR_ON_NULL_VALUES_DEFAULT);
         setFieldToDefaultValues(config, ENABLE_COMBINE_FLUSH, ENABLE_COMBINE_FLUSH_DEFAULT);
+        setFieldToDefaultValues(
+                config,
+                SINK_S3_PATH_STYLE_ACCESS,
+                String.valueOf(SINK_S3_PATH_STYLE_ACCESS_DEFAULT));
         setFieldToDefaultValues(config, DORIS_ENABLE_TLS, String.valueOf(DORIS_ENABLE_TLS_DEFAULT));
         setFieldToDefaultValues(
                 config, DORIS_TLS_CA_CERTIFICATE_PATH, DORIS_TLS_CA_CERTIFICATE_PATH_DEFAULT);
@@ -411,7 +424,77 @@ public class DorisSinkConnectorConfig {
                         ConfigDef.Type.BOOLEAN,
                         JMX_OPT_DEFAULT,
                         ConfigDef.Importance.HIGH,
-                        "Whether to enable JMX MBeans for custom metrics");
+                        "Whether to enable JMX MBeans for custom metrics")
+                .define(
+                        SINK_S3_ENDPOINT,
+                        Type.STRING,
+                        null,
+                        Importance.HIGH,
+                        "S3-compatible endpoint",
+                        TVF_CONFIG,
+                        1,
+                        ConfigDef.Width.NONE,
+                        SINK_S3_ENDPOINT)
+                .define(
+                        SINK_S3_REGION,
+                        Type.STRING,
+                        null,
+                        Importance.HIGH,
+                        "S3 region",
+                        TVF_CONFIG,
+                        2,
+                        ConfigDef.Width.NONE,
+                        SINK_S3_REGION)
+                .define(
+                        SINK_S3_BUCKET,
+                        Type.STRING,
+                        null,
+                        Importance.HIGH,
+                        "S3 bucket",
+                        TVF_CONFIG,
+                        3,
+                        ConfigDef.Width.NONE,
+                        SINK_S3_BUCKET)
+                .define(
+                        SINK_S3_PREFIX,
+                        Type.STRING,
+                        null,
+                        Importance.HIGH,
+                        "S3 object prefix",
+                        TVF_CONFIG,
+                        4,
+                        ConfigDef.Width.NONE,
+                        SINK_S3_PREFIX)
+                .define(
+                        SINK_S3_ACCESS_KEY,
+                        Type.PASSWORD,
+                        null,
+                        Importance.HIGH,
+                        "S3 access key",
+                        TVF_CONFIG,
+                        5,
+                        ConfigDef.Width.NONE,
+                        SINK_S3_ACCESS_KEY)
+                .define(
+                        SINK_S3_SECRET_KEY,
+                        Type.PASSWORD,
+                        null,
+                        Importance.HIGH,
+                        "S3 secret key",
+                        TVF_CONFIG,
+                        6,
+                        ConfigDef.Width.NONE,
+                        SINK_S3_SECRET_KEY)
+                .define(
+                        SINK_S3_PATH_STYLE_ACCESS,
+                        Type.BOOLEAN,
+                        SINK_S3_PATH_STYLE_ACCESS_DEFAULT,
+                        Importance.MEDIUM,
+                        "Whether to use S3 path-style access",
+                        TVF_CONFIG,
+                        7,
+                        ConfigDef.Width.NONE,
+                        SINK_S3_PATH_STYLE_ACCESS);
     }
 
     public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/S3TvfOptions.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/S3TvfOptions.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.cfg;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/** Options for staging Kafka records in S3-compatible object storage. */
+public class S3TvfOptions {
+    private final String endpoint;
+    private final String region;
+    private final String bucket;
+    private final String prefix;
+    private final String accessKey;
+    private final String secretKey;
+    private final boolean pathStyleAccess;
+
+    private S3TvfOptions(Builder builder) {
+        this.endpoint = requireNonEmpty(builder.endpoint, "sink.s3.endpoint");
+        this.region = requireNonEmpty(builder.region, "sink.s3.region");
+        this.bucket = requireNonEmpty(builder.bucket, "sink.s3.bucket");
+        this.prefix = requireNonEmpty(builder.prefix, "sink.s3.prefix");
+        this.accessKey = requireNonEmpty(builder.accessKey, "sink.s3.access-key");
+        this.secretKey = requireNonEmpty(builder.secretKey, "sink.s3.secret-key");
+        this.pathStyleAccess = builder.pathStyleAccess;
+        validateEndpoint(endpoint);
+        validatePrefix(prefix);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public boolean isPathStyleAccess() {
+        return pathStyleAccess;
+    }
+
+    @Override
+    public String toString() {
+        return "S3TvfOptions{"
+                + "endpoint='"
+                + endpoint
+                + '\''
+                + ", region='"
+                + region
+                + '\''
+                + ", bucket='"
+                + bucket
+                + '\''
+                + ", prefix='"
+                + prefix
+                + '\''
+                + ", pathStyleAccess="
+                + pathStyleAccess
+                + '}';
+    }
+
+    private static String requireNonEmpty(String value, String option) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(option + " must not be empty");
+        }
+        return value.trim();
+    }
+
+    private static void validatePrefix(String prefix) {
+        for (char character : "*?[]{},\\".toCharArray()) {
+            if (prefix.indexOf(character) >= 0) {
+                throw new IllegalArgumentException(
+                        "sink.s3.prefix must not contain glob characters: * ? [ ] { } , \\");
+            }
+        }
+    }
+
+    private static void validateEndpoint(String endpoint) {
+        try {
+            URI uri = new URI(endpoint);
+            String scheme = uri.getScheme();
+            if (!("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
+                    || uri.getHost() == null) {
+                throw new IllegalArgumentException(
+                        "sink.s3.endpoint must be an absolute HTTP or HTTPS URI");
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("sink.s3.endpoint must be a valid URI", e);
+        }
+    }
+
+    public static class Builder {
+        private String endpoint;
+        private String region;
+        private String bucket;
+        private String prefix;
+        private String accessKey;
+        private String secretKey;
+        private boolean pathStyleAccess;
+
+        public Builder setEndpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder setRegion(String region) {
+            this.region = region;
+            return this;
+        }
+
+        public Builder setBucket(String bucket) {
+            this.bucket = bucket;
+            return this;
+        }
+
+        public Builder setPrefix(String prefix) {
+            this.prefix = prefix;
+            return this;
+        }
+
+        public Builder setAccessKey(String accessKey) {
+            this.accessKey = accessKey;
+            return this;
+        }
+
+        public Builder setSecretKey(String secretKey) {
+            this.secretKey = secretKey;
+            return this;
+        }
+
+        public Builder setPathStyleAccess(boolean pathStyleAccess) {
+            this.pathStyleAccess = pathStyleAccess;
+            return this;
+        }
+
+        public S3TvfOptions build() {
+            return new S3TvfOptions(this);
+        }
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/cfg/TvfColumnUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/cfg/TvfColumnUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.cfg;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.doris.kafka.connector.writer.LoadConstants;
+
+/** Resolves the fixed physical columns used by TVF write mode. */
+public final class TvfColumnUtils {
+    private static final String COLUMNS_OPTION = "sink.properties.columns";
+    private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*");
+
+    private TvfColumnUtils() {}
+
+    public static List<String> resolveColumns(String configuredColumns) {
+        if (configuredColumns == null || configuredColumns.trim().isEmpty()) {
+            throw new IllegalArgumentException(COLUMNS_OPTION + " must not be empty");
+        }
+
+        List<String> columns = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (String rawColumn : configuredColumns.split(",", -1)) {
+            String value = rawColumn.trim();
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(COLUMNS_OPTION + " contains an empty column");
+            }
+            String column = resolveIdentifier(value);
+            if (LoadConstants.DORIS_DELETE_SIGN.equalsIgnoreCase(column)) {
+                throw new IllegalArgumentException(
+                        COLUMNS_OPTION + " must not contain " + LoadConstants.DORIS_DELETE_SIGN);
+            }
+            if (!seen.add(column.toLowerCase(Locale.ROOT))) {
+                throw new IllegalArgumentException(
+                        COLUMNS_OPTION + " contains duplicate column: " + column);
+            }
+            columns.add(column);
+        }
+        return Collections.unmodifiableList(columns);
+    }
+
+    private static String resolveIdentifier(String value) {
+        if (value.length() >= 2 && value.startsWith("`") && value.endsWith("`")) {
+            String identifier = value.substring(1, value.length() - 1).replace("``", "`");
+            if (!identifier.isEmpty()) {
+                return identifier;
+            }
+        } else if (UNQUOTED_IDENTIFIER.matcher(value).matches()) {
+            return value;
+        }
+        throw new IllegalArgumentException(
+                COLUMNS_OPTION + " only supports fixed physical column identifiers: " + value);
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/service/DorisCombinedSinkService.java
+++ b/src/main/java/org/apache/doris/kafka/connector/service/DorisCombinedSinkService.java
@@ -22,8 +22,10 @@ package org.apache.doris.kafka.connector.service;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.doris.kafka.connector.writer.AsyncS3TvfWriter;
 import org.apache.doris.kafka.connector.writer.AsyncStreamLoadWriter;
 import org.apache.doris.kafka.connector.writer.DorisWriter;
+import org.apache.doris.kafka.connector.writer.load.LoadModel;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -48,6 +50,8 @@ public class DorisCombinedSinkService extends DorisDefaultSinkService {
                 // When the stream load asynchronous thread down,
                 // it needs to be restarted when retrying
                 ((AsyncStreamLoadWriter) wr).start();
+            } else if (wr instanceof AsyncS3TvfWriter) {
+                ((AsyncS3TvfWriter) wr).resetAfterUploadFailure();
             }
         }
     }
@@ -69,19 +73,32 @@ public class DorisCombinedSinkService extends DorisDefaultSinkService {
 
             // Only by topic
             int partition = -1;
-            DorisWriter dorisWriter =
-                    new AsyncStreamLoadWriter(
-                            tableName,
-                            topic,
-                            partition,
-                            dorisOptions,
-                            conn,
-                            dorisSystemService,
-                            connectMonitor);
+            DorisWriter dorisWriter = createWriter(tableName, topic, partition);
 
             writer.put(writerKey, dorisWriter);
             metricsJmxReporter.start();
         }
+    }
+
+    protected DorisWriter createWriter(String tableName, String topic, int partition) {
+        if (LoadModel.TVF.equals(dorisOptions.getLoadModel())) {
+            return new AsyncS3TvfWriter(
+                    tableName,
+                    topic,
+                    partition,
+                    dorisOptions,
+                    conn,
+                    dorisSystemService,
+                    connectMonitor);
+        }
+        return new AsyncStreamLoadWriter(
+                tableName,
+                topic,
+                partition,
+                dorisOptions,
+                conn,
+                dorisSystemService,
+                connectMonitor);
     }
 
     @Override

--- a/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/utils/ConfigCheckUtils.java
@@ -29,6 +29,8 @@ import java.util.regex.Pattern;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
 import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
 import org.apache.doris.kafka.connector.cfg.DorisTlsOptions;
+import org.apache.doris.kafka.connector.cfg.S3TvfOptions;
+import org.apache.doris.kafka.connector.cfg.TvfColumnUtils;
 import org.apache.doris.kafka.connector.converter.ConverterMode;
 import org.apache.doris.kafka.connector.converter.schema.SchemaEvolutionMode;
 import org.apache.doris.kafka.connector.exception.ArgumentsException;
@@ -219,6 +221,46 @@ public class ConfigCheckUtils {
                     DorisSinkConnectorConfig.DELIVERY_GUARANTEE,
                     DeliveryGuarantee.EXACTLY_ONCE.name());
             configIsValid = false;
+        }
+
+        if (configIsValid && LoadModel.TVF.getName().equalsIgnoreCase(loadModel)) {
+            if (!Boolean.parseBoolean(enableCombineFlush)
+                    || !DeliveryGuarantee.AT_LEAST_ONCE
+                            .getName()
+                            .equalsIgnoreCase(deliveryGuarantee)) {
+                LOG.error(
+                        "S3 TVF requires enable.combine.flush=true and delivery.guarantee=at_least_once");
+                configIsValid = false;
+            } else {
+                try {
+                    String pathStyleAccess =
+                            config.getOrDefault(
+                                    DorisSinkConnectorConfig.SINK_S3_PATH_STYLE_ACCESS,
+                                    String.valueOf(
+                                            DorisSinkConnectorConfig
+                                                    .SINK_S3_PATH_STYLE_ACCESS_DEFAULT));
+                    if (!isBoolean(pathStyleAccess)) {
+                        throw new IllegalArgumentException(
+                                DorisSinkConnectorConfig.SINK_S3_PATH_STYLE_ACCESS
+                                        + " must be true or false");
+                    }
+                    S3TvfOptions.builder()
+                            .setEndpoint(config.get(DorisSinkConnectorConfig.SINK_S3_ENDPOINT))
+                            .setRegion(config.get(DorisSinkConnectorConfig.SINK_S3_REGION))
+                            .setBucket(config.get(DorisSinkConnectorConfig.SINK_S3_BUCKET))
+                            .setPrefix(config.get(DorisSinkConnectorConfig.SINK_S3_PREFIX))
+                            .setAccessKey(config.get(DorisSinkConnectorConfig.SINK_S3_ACCESS_KEY))
+                            .setSecretKey(config.get(DorisSinkConnectorConfig.SINK_S3_SECRET_KEY))
+                            .setPathStyleAccess(Boolean.parseBoolean(pathStyleAccess))
+                            .build();
+                    TvfColumnUtils.resolveColumns(
+                            config.get(
+                                    DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX + "columns"));
+                } catch (IllegalArgumentException e) {
+                    LOG.error("Invalid S3 TVF configuration: {}", e.getMessage());
+                    configIsValid = false;
+                }
+            }
         }
 
         String converterMode = config.get(DorisSinkConnectorConfig.CONVERTER_MODE);

--- a/src/main/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriter.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.doris.kafka.connector.cfg.DorisOptions;
+import org.apache.doris.kafka.connector.cfg.S3TvfOptions;
+import org.apache.doris.kafka.connector.connection.ConnectionProvider;
+import org.apache.doris.kafka.connector.converter.RecordService;
+import org.apache.doris.kafka.connector.exception.DorisException;
+import org.apache.doris.kafka.connector.metrics.DorisConnectMonitor;
+import org.apache.doris.kafka.connector.service.DorisSystemService;
+import org.apache.doris.kafka.connector.writer.load.DefaultThreadFactory;
+import org.apache.doris.kafka.connector.writer.s3.S3ClientObjectStore;
+import org.apache.doris.kafka.connector.writer.s3.S3ObjectStore;
+import org.apache.doris.kafka.connector.writer.s3.S3TvfLoad;
+import org.apache.doris.kafka.connector.writer.s3.S3TvfRecordSerializer;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Stages combined Kafka records as JSON Lines files and commits them through the S3 TVF. */
+public class AsyncS3TvfWriter extends DorisWriter {
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncS3TvfWriter.class);
+    private static final byte NEW_LINE = '\n';
+    private static final int UPLOAD_QUEUE_SIZE = 1;
+    private static final Runnable UPLOAD_BARRIER = () -> {};
+
+    private S3ObjectStore objectStore;
+    private S3TvfLoad load;
+    private S3TvfRecordSerializer serializer;
+    private Supplier<String> batchUuidSupplier;
+    private ExecutorService uploadExecutor;
+    private S3TvfOptions s3Options;
+    private String normalizedLabelPrefix;
+    private String normalizedTable;
+
+    private final ByteArrayOutputStream tvfBuffer = new ByteArrayOutputStream();
+    private final BlockingQueue<Runnable> uploadQueue =
+            new LinkedBlockingQueue<>(UPLOAD_QUEUE_SIZE);
+    private final AtomicReference<DorisException> uploadException = new AtomicReference<>();
+    private final List<String> uploadedObjectKeys = new ArrayList<>();
+    private int bufferedRecords;
+    private String batchUuid;
+    private int fileNumber;
+
+    public AsyncS3TvfWriter(
+            String tableName,
+            String topic,
+            int partition,
+            DorisOptions dorisOptions,
+            ConnectionProvider connectionProvider,
+            DorisSystemService dorisSystemService,
+            DorisConnectMonitor connectMonitor) {
+        super(
+                tableName,
+                topic,
+                partition,
+                dorisOptions,
+                connectionProvider,
+                dorisSystemService,
+                connectMonitor);
+        initialize(
+                new S3ClientObjectStore(dorisOptions.getS3TvfOptions()),
+                new S3TvfLoad(connectionProvider, dorisOptions, dbName, this.tableName),
+                this.recordService,
+                () -> UUID.randomUUID().toString(),
+                Executors.newSingleThreadExecutor(
+                        new DefaultThreadFactory("s3-tvf-upload-" + dorisOptions.getTaskId())));
+    }
+
+    AsyncS3TvfWriter(
+            String tableName,
+            String topic,
+            int partition,
+            DorisOptions dorisOptions,
+            ConnectionProvider connectionProvider,
+            DorisSystemService dorisSystemService,
+            DorisConnectMonitor connectMonitor,
+            RecordService recordService,
+            S3ObjectStore objectStore,
+            S3TvfLoad load,
+            Supplier<String> batchUuidSupplier,
+            ExecutorService uploadExecutor) {
+        super(
+                tableName,
+                topic,
+                partition,
+                dorisOptions,
+                connectionProvider,
+                dorisSystemService,
+                connectMonitor);
+        initialize(objectStore, load, recordService, batchUuidSupplier, uploadExecutor);
+    }
+
+    private void initialize(
+            S3ObjectStore objectStore,
+            S3TvfLoad load,
+            RecordService recordService,
+            Supplier<String> batchUuidSupplier,
+            ExecutorService uploadExecutor) {
+        this.objectStore = objectStore;
+        this.load = load;
+        this.recordService = recordService;
+        this.batchUuidSupplier = batchUuidSupplier;
+        this.uploadExecutor = uploadExecutor;
+        this.s3Options = dorisOptions.getS3TvfOptions();
+        this.serializer =
+                new S3TvfRecordSerializer(
+                        dorisOptions.getTvfColumns(), dorisOptions.isEnableDelete());
+        this.normalizedLabelPrefix = normalize(dorisOptions.getLabelPrefix());
+        this.normalizedTable = normalize(tableIdentifier);
+        this.uploadExecutor.execute(this::runUploadLoop);
+    }
+
+    @Override
+    public synchronized void insert(SinkRecord record) {
+        checkUploadException();
+        String processedRecord = recordService.getProcessedRecord(record);
+        if (processedRecord == null) {
+            return;
+        }
+        String serialized = serializer.serialize(processedRecord);
+        if (serialized.isEmpty()) {
+            return;
+        }
+        byte[] bytes = serialized.getBytes(StandardCharsets.UTF_8);
+        int bytesWithNewLine = bytes.length + 1;
+        tvfBuffer.write(bytes, 0, bytes.length);
+        tvfBuffer.write(NEW_LINE);
+        bufferedRecords++;
+        connectMonitor.addAndGetBuffMemoryUsage(bytesWithNewLine);
+
+        if (tvfBuffer.size() >= dorisOptions.getFileSize()
+                || (dorisOptions.getRecordNum() != 0
+                        && bufferedRecords >= dorisOptions.getRecordNum())) {
+            submitBuffer();
+        }
+    }
+
+    @Override
+    public synchronized void flushBuffer() {
+        submitBuffer();
+    }
+
+    @Override
+    public synchronized void commitFlush() {
+        submitBuffer();
+        if (batchUuid == null) {
+            return;
+        }
+
+        waitForUploads();
+        List<String> objectKeys = Collections.unmodifiableList(new ArrayList<>(uploadedObjectKeys));
+        String label = buildLabel();
+        load.load(label, objectKeys);
+        uploadedObjectKeys.clear();
+        batchUuid = null;
+        fileNumber = 0;
+    }
+
+    private void submitBuffer() {
+        if (tvfBuffer.size() == 0) {
+            return;
+        }
+        ensureBatch();
+        int currentFileNumber = fileNumber++;
+        String label = buildLabel();
+        String fileName =
+                label + "_" + dorisOptions.getTaskId() + "_" + currentFileNumber + ".json";
+        String objectKey = buildObjectKey(fileName);
+        byte[] content = tvfBuffer.toByteArray();
+        int recordCount = bufferedRecords;
+        putUpload(
+                () -> {
+                    if (uploadException.get() != null) {
+                        return;
+                    }
+                    try {
+                        objectStore.put(objectKey, content);
+                        uploadedObjectKeys.add(objectKey);
+                    } catch (Exception e) {
+                        uploadException.compareAndSet(
+                                null,
+                                new DorisException("Failed to upload S3 TVF file " + objectKey, e));
+                    }
+                });
+        connectMonitor.updateBufferMetrics(content.length, recordCount);
+        connectMonitor.addAndGetTotalSizeOfData(content.length);
+        connectMonitor.addAndGetTotalNumberOfRecord(recordCount);
+        connectMonitor.resetMemoryUsage();
+        tvfBuffer.reset();
+        bufferedRecords = 0;
+        LOG.info(
+                "Queued S3 TVF file {} for upload ({} bytes, {} records)",
+                fileName,
+                content.length,
+                recordCount);
+    }
+
+    private void runUploadLoop() {
+        LOG.info("S3 TVF upload worker started");
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                uploadQueue.take().run();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            LOG.info("S3 TVF upload worker stopped");
+        }
+    }
+
+    private void waitForUploads() {
+        for (int i = 0; i < UPLOAD_QUEUE_SIZE + 1; i++) {
+            putUpload(UPLOAD_BARRIER);
+        }
+    }
+
+    private void putUpload(Runnable upload) {
+        checkUploadException();
+        try {
+            uploadQueue.put(upload);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DorisException("Interrupted while queuing an S3 TVF upload", e);
+        }
+        checkUploadException();
+    }
+
+    private void checkUploadException() {
+        DorisException exception = uploadException.get();
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    /** Clears a failed upload batch so Kafka Connect can retry the records. */
+    public synchronized void resetAfterUploadFailure() {
+        if (uploadException.getAndSet(null) == null) {
+            return;
+        }
+        uploadQueue.clear();
+        uploadedObjectKeys.clear();
+        tvfBuffer.reset();
+        bufferedRecords = 0;
+        batchUuid = null;
+        fileNumber = 0;
+        connectMonitor.resetMemoryUsage();
+        LOG.info("Reset failed S3 TVF upload batch for retry");
+    }
+
+    private void ensureBatch() {
+        if (batchUuid == null) {
+            String generated = batchUuidSupplier.get();
+            if (generated == null || generated.trim().isEmpty()) {
+                throw new DorisException("Unable to generate an S3 TVF batch UUID");
+            }
+            batchUuid = generated.replace("-", "");
+        }
+    }
+
+    private String buildLabel() {
+        ensureBatch();
+        return normalizedLabelPrefix + "_" + normalizedTable + "_" + batchUuid;
+    }
+
+    private String buildObjectKey(String fileName) {
+        String prefix = s3Options.getPrefix();
+        while (prefix.endsWith("/")) {
+            prefix = prefix.substring(0, prefix.length() - 1);
+        }
+        return prefix
+                + "/"
+                + normalizedLabelPrefix
+                + "/"
+                + normalizedTable
+                + "/"
+                + batchUuid
+                + "/"
+                + fileName;
+    }
+
+    private static String normalize(String value) {
+        return value.replaceAll("[^A-Za-z0-9_-]", "_");
+    }
+
+    @Override
+    public void commit(int partition) {
+        // Combined S3 TVF mode commits all task offsets after commitFlush succeeds.
+    }
+
+    @Override
+    public long getOffset() {
+        return 0;
+    }
+
+    @Override
+    public void fetchOffset() {
+        // S3 TVF mode relies on Kafka Connect offsets and does not persist offsets in Doris.
+    }
+
+    @Override
+    public void close() {
+        uploadExecutor.shutdownNow();
+        objectStore.close();
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriter.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriter.java
@@ -26,11 +26,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
 import org.apache.doris.kafka.connector.cfg.S3TvfOptions;
 import org.apache.doris.kafka.connector.connection.ConnectionProvider;
@@ -57,15 +57,13 @@ public class AsyncS3TvfWriter extends DorisWriter {
     private S3ObjectStore objectStore;
     private S3TvfLoad load;
     private S3TvfRecordSerializer serializer;
-    private Supplier<String> batchUuidSupplier;
     private ExecutorService uploadExecutor;
     private S3TvfOptions s3Options;
     private String normalizedLabelPrefix;
     private String normalizedTable;
 
     private final ByteArrayOutputStream tvfBuffer = new ByteArrayOutputStream();
-    private final BlockingQueue<Runnable> uploadQueue =
-            new LinkedBlockingQueue<>(UPLOAD_QUEUE_SIZE);
+    private final BlockingQueue<Runnable> uploadQueue;
     private final AtomicReference<DorisException> uploadException = new AtomicReference<>();
     private final List<String> uploadedObjectKeys = new ArrayList<>();
     private int bufferedRecords;
@@ -88,11 +86,11 @@ public class AsyncS3TvfWriter extends DorisWriter {
                 connectionProvider,
                 dorisSystemService,
                 connectMonitor);
+        this.uploadQueue = new LinkedBlockingQueue<>(UPLOAD_QUEUE_SIZE);
         initialize(
                 new S3ClientObjectStore(dorisOptions.getS3TvfOptions()),
                 new S3TvfLoad(connectionProvider, dorisOptions, dbName, this.tableName),
                 this.recordService,
-                () -> UUID.randomUUID().toString(),
                 Executors.newSingleThreadExecutor(
                         new DefaultThreadFactory("s3-tvf-upload-" + dorisOptions.getTaskId())));
     }
@@ -108,8 +106,35 @@ public class AsyncS3TvfWriter extends DorisWriter {
             RecordService recordService,
             S3ObjectStore objectStore,
             S3TvfLoad load,
-            Supplier<String> batchUuidSupplier,
             ExecutorService uploadExecutor) {
+        this(
+                tableName,
+                topic,
+                partition,
+                dorisOptions,
+                connectionProvider,
+                dorisSystemService,
+                connectMonitor,
+                recordService,
+                objectStore,
+                load,
+                uploadExecutor,
+                new LinkedBlockingQueue<>(UPLOAD_QUEUE_SIZE));
+    }
+
+    AsyncS3TvfWriter(
+            String tableName,
+            String topic,
+            int partition,
+            DorisOptions dorisOptions,
+            ConnectionProvider connectionProvider,
+            DorisSystemService dorisSystemService,
+            DorisConnectMonitor connectMonitor,
+            RecordService recordService,
+            S3ObjectStore objectStore,
+            S3TvfLoad load,
+            ExecutorService uploadExecutor,
+            BlockingQueue<Runnable> uploadQueue) {
         super(
                 tableName,
                 topic,
@@ -118,19 +143,18 @@ public class AsyncS3TvfWriter extends DorisWriter {
                 connectionProvider,
                 dorisSystemService,
                 connectMonitor);
-        initialize(objectStore, load, recordService, batchUuidSupplier, uploadExecutor);
+        this.uploadQueue = uploadQueue;
+        initialize(objectStore, load, recordService, uploadExecutor);
     }
 
     private void initialize(
             S3ObjectStore objectStore,
             S3TvfLoad load,
             RecordService recordService,
-            Supplier<String> batchUuidSupplier,
             ExecutorService uploadExecutor) {
         this.objectStore = objectStore;
         this.load = load;
         this.recordService = recordService;
-        this.batchUuidSupplier = batchUuidSupplier;
         this.uploadExecutor = uploadExecutor;
         this.s3Options = dorisOptions.getS3TvfOptions();
         this.serializer =
@@ -174,24 +198,25 @@ public class AsyncS3TvfWriter extends DorisWriter {
     @Override
     public synchronized void commitFlush() {
         submitBuffer();
-        if (batchUuid == null) {
+        if (!hasActiveBatch()) {
             return;
         }
 
         waitForUploads();
         List<String> objectKeys = Collections.unmodifiableList(new ArrayList<>(uploadedObjectKeys));
         String label = buildLabel();
-        load.load(label, objectKeys);
-        uploadedObjectKeys.clear();
-        batchUuid = null;
-        fileNumber = 0;
+        try {
+            load.load(label, objectKeys);
+        } finally {
+            finishBatch();
+        }
     }
 
     private void submitBuffer() {
         if (tvfBuffer.size() == 0) {
             return;
         }
-        ensureBatch();
+        startBatchIfNeeded();
         int currentFileNumber = fileNumber++;
         String label = buildLabel();
         String fileName =
@@ -265,31 +290,54 @@ public class AsyncS3TvfWriter extends DorisWriter {
 
     /** Clears a failed upload batch so Kafka Connect can retry the records. */
     public synchronized void resetAfterUploadFailure() {
-        if (uploadException.getAndSet(null) == null) {
+        if (uploadException.get() == null) {
             return;
         }
         uploadQueue.clear();
-        uploadedObjectKeys.clear();
+        awaitUploadWorkerIdle();
+        finishBatch();
         tvfBuffer.reset();
         bufferedRecords = 0;
-        batchUuid = null;
-        fileNumber = 0;
         connectMonitor.resetMemoryUsage();
+        uploadException.set(null);
         LOG.info("Reset failed S3 TVF upload batch for retry");
     }
 
-    private void ensureBatch() {
-        if (batchUuid == null) {
-            String generated = batchUuidSupplier.get();
-            if (generated == null || generated.trim().isEmpty()) {
-                throw new DorisException("Unable to generate an S3 TVF batch UUID");
-            }
-            batchUuid = generated.replace("-", "");
+    /**
+     * Waits until the single upload worker has passed a queue barrier.
+     *
+     * <p>Clearing the queue cannot cancel a task that the worker has already dequeued. The upload
+     * failure must remain visible until such a task finishes, otherwise it could upload an object
+     * from the failed batch and add its key to the next batch.
+     */
+    private void awaitUploadWorkerIdle() {
+        CountDownLatch drained = new CountDownLatch(1);
+        try {
+            uploadQueue.put(drained::countDown);
+            drained.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DorisException("Interrupted while draining failed S3 TVF uploads", e);
         }
     }
 
+    private void startBatchIfNeeded() {
+        if (!hasActiveBatch()) {
+            batchUuid = UUID.randomUUID().toString().replace("-", "");
+        }
+    }
+
+    private boolean hasActiveBatch() {
+        return batchUuid != null;
+    }
+
+    private void finishBatch() {
+        uploadedObjectKeys.clear();
+        batchUuid = null;
+        fileNumber = 0;
+    }
+
     private String buildLabel() {
-        ensureBatch();
         return normalizedLabelPrefix + "_" + normalizedTable + "_" + batchUuid;
     }
 

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3ClientObjectStore.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3ClientObjectStore.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import java.io.IOException;
+import java.net.URI;
+import org.apache.doris.kafka.connector.cfg.S3TvfOptions;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/** AWS SDK based object store used by the S3 TVF writer. */
+public class S3ClientObjectStore implements S3ObjectStore {
+    private static final String JSON_LINES_CONTENT_TYPE = "application/x-ndjson";
+
+    private final S3Client s3Client;
+    private final String bucket;
+
+    public S3ClientObjectStore(S3TvfOptions options) {
+        this(createClient(options), options.getBucket());
+    }
+
+    S3ClientObjectStore(S3Client s3Client, String bucket) {
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+    }
+
+    @Override
+    public void put(String objectKey, byte[] content) throws IOException {
+        PutObjectRequest request =
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(objectKey)
+                        .contentType(JSON_LINES_CONTENT_TYPE)
+                        .build();
+        try {
+            s3Client.putObject(request, RequestBody.fromBytes(content));
+        } catch (RuntimeException e) {
+            throw new IOException("Failed to upload staged S3 object " + objectKey, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        s3Client.close();
+    }
+
+    private static S3Client createClient(S3TvfOptions options) {
+        return S3Client.builder()
+                .endpointOverride(URI.create(options.getEndpoint()))
+                .region(Region.of(options.getRegion()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        options.getAccessKey(), options.getSecretKey())))
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
+                .serviceConfiguration(
+                        S3Configuration.builder()
+                                .pathStyleAccessEnabled(options.isPathStyleAccess())
+                                .build())
+                .build();
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3ObjectStore.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3ObjectStore.java
@@ -17,30 +17,14 @@
  * under the License.
  */
 
-package org.apache.doris.kafka.connector.writer.load;
+package org.apache.doris.kafka.connector.writer.s3;
 
-public enum LoadModel {
-    STREAM_LOAD("stream_load"),
+import java.io.IOException;
 
-    COPY_INTO("copy_into"),
+/** Object storage operations needed by the S3 TVF writer. */
+public interface S3ObjectStore extends AutoCloseable {
+    void put(String objectKey, byte[] content) throws IOException;
 
-    TVF("tvf");
-
-    private String name;
-
-    LoadModel(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public static LoadModel of(String name) {
-        return LoadModel.valueOf(name.toUpperCase());
-    }
-
-    public static String[] instances() {
-        return new String[] {STREAM_LOAD.name, COPY_INTO.name, TVF.name};
-    }
+    @Override
+    void close();
 }

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoad.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoad.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 /** Executes S3 TVF INSERT statements and reconciles ambiguous Label results. */
 public class S3TvfLoad {
     private static final Logger LOG = LoggerFactory.getLogger(S3TvfLoad.class);
+    private static final int MAX_INSERT_RETRIES = 3;
+    private static final int MAX_LABEL_STATE_RETRIES = 3;
     private static final Pattern SESSION_VARIABLE = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
 
     private final ConnectionProvider connectionProvider;
@@ -50,7 +52,6 @@ public class S3TvfLoad {
     private final List<String> columns;
     private final boolean deleteSignEnabled;
     private final Map<String, String> sessionVariables;
-    private final int maxRetries;
 
     public S3TvfLoad(
             ConnectionProvider connectionProvider,
@@ -64,8 +65,7 @@ public class S3TvfLoad {
                 table,
                 options.getTvfColumns(),
                 options.isEnableDelete(),
-                options.getSessionVariables(),
-                options.getMaxRetries());
+                options.getSessionVariables());
     }
 
     S3TvfLoad(
@@ -75,8 +75,7 @@ public class S3TvfLoad {
             String table,
             List<String> columns,
             boolean deleteSignEnabled,
-            Map<String, String> sessionVariables,
-            int maxRetries) {
+            Map<String, String> sessionVariables) {
         this.connectionProvider = connectionProvider;
         this.sqlBuilder = sqlBuilder;
         this.database = database;
@@ -84,14 +83,13 @@ public class S3TvfLoad {
         this.columns = Collections.unmodifiableList(columns);
         this.deleteSignEnabled = deleteSignEnabled;
         this.sessionVariables = Collections.unmodifiableMap(new LinkedHashMap<>(sessionVariables));
-        this.maxRetries = maxRetries;
     }
 
     public void load(String label, List<String> objectKeys) {
         String sql =
                 sqlBuilder.buildInsertSql(
                         database, table, label, objectKeys, columns, deleteSignEnabled);
-        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+        for (int attempt = 0; attempt <= MAX_INSERT_RETRIES; attempt++) {
             try {
                 executeInsert(sql);
                 LOG.info("S3 TVF load committed with label {}", label);
@@ -112,7 +110,7 @@ public class S3TvfLoad {
                         throw failure(label, reconcileFailure);
                     }
                 }
-                if (attempt == maxRetries) {
+                if (attempt == MAX_INSERT_RETRIES) {
                     throw failure(label, e);
                 }
             }
@@ -163,7 +161,7 @@ public class S3TvfLoad {
                     continue;
                 }
             }
-            if (retries++ >= maxRetries) {
+            if (retries++ >= MAX_LABEL_STATE_RETRIES) {
                 break;
             }
             state = getLoadState(label);

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoad.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoad.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import static org.apache.doris.kafka.connector.writer.s3.TvfSqlUtils.quoteIdentifier;
+import static org.apache.doris.kafka.connector.writer.s3.TvfSqlUtils.quoteLiteral;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.apache.doris.kafka.connector.cfg.DorisOptions;
+import org.apache.doris.kafka.connector.connection.ConnectionProvider;
+import org.apache.doris.kafka.connector.exception.DorisException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Executes S3 TVF INSERT statements and reconciles ambiguous Label results. */
+public class S3TvfLoad {
+    private static final Logger LOG = LoggerFactory.getLogger(S3TvfLoad.class);
+    private static final Pattern SESSION_VARIABLE = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    private final ConnectionProvider connectionProvider;
+    private final S3TvfSqlBuilder sqlBuilder;
+    private final String database;
+    private final String table;
+    private final List<String> columns;
+    private final boolean deleteSignEnabled;
+    private final Map<String, String> sessionVariables;
+    private final int maxRetries;
+
+    public S3TvfLoad(
+            ConnectionProvider connectionProvider,
+            DorisOptions options,
+            String database,
+            String table) {
+        this(
+                connectionProvider,
+                new S3TvfSqlBuilder(options.getS3TvfOptions()),
+                database,
+                table,
+                options.getTvfColumns(),
+                options.isEnableDelete(),
+                options.getSessionVariables(),
+                options.getMaxRetries());
+    }
+
+    S3TvfLoad(
+            ConnectionProvider connectionProvider,
+            S3TvfSqlBuilder sqlBuilder,
+            String database,
+            String table,
+            List<String> columns,
+            boolean deleteSignEnabled,
+            Map<String, String> sessionVariables,
+            int maxRetries) {
+        this.connectionProvider = connectionProvider;
+        this.sqlBuilder = sqlBuilder;
+        this.database = database;
+        this.table = table;
+        this.columns = Collections.unmodifiableList(columns);
+        this.deleteSignEnabled = deleteSignEnabled;
+        this.sessionVariables = Collections.unmodifiableMap(new LinkedHashMap<>(sessionVariables));
+        this.maxRetries = maxRetries;
+    }
+
+    public void load(String label, List<String> objectKeys) {
+        String sql =
+                sqlBuilder.buildInsertSql(
+                        database, table, label, objectKeys, columns, deleteSignEnabled);
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+                executeInsert(sql);
+                LOG.info("S3 TVF load committed with label {}", label);
+                return;
+            } catch (SQLException e) {
+                LOG.warn(
+                        "S3 TVF insert failed for label {} on attempt {} (SQLState={}, errorCode={})",
+                        label,
+                        attempt + 1,
+                        e.getSQLState(),
+                        e.getErrorCode());
+                if (isLabelAlreadyUsed(e, label)) {
+                    try {
+                        if (handleLabelAlreadyUsed(label)) {
+                            return;
+                        }
+                    } catch (SQLException reconcileFailure) {
+                        throw failure(label, reconcileFailure);
+                    }
+                }
+                if (attempt == maxRetries) {
+                    throw failure(label, e);
+                }
+            }
+        }
+    }
+
+    private void executeInsert(String sql) throws SQLException {
+        try (Statement statement = connection().createStatement()) {
+            for (Map.Entry<String, String> entry : sessionVariables.entrySet()) {
+                if (!SESSION_VARIABLE.matcher(entry.getKey()).matches()) {
+                    throw new DorisException("Invalid Doris session variable: " + entry.getKey());
+                }
+                statement.execute(
+                        "SET SESSION " + entry.getKey() + " = " + quoteLiteral(entry.getValue()));
+            }
+            statement.execute(sql);
+        }
+    }
+
+    private boolean handleLabelAlreadyUsed(String label) throws SQLException {
+        S3TvfLoadState state = getLoadState(label);
+        int retries = 0;
+        while (true) {
+            LOG.info("S3 TVF label {} load state is {}", label, state);
+            if (state == S3TvfLoadState.FINISHED) {
+                LOG.info("S3 TVF label {} was already committed", label);
+                return true;
+            }
+            if (state == S3TvfLoadState.CANCELLED) {
+                LOG.info("S3 TVF label {} was cancelled; retrying the insert", label);
+                return false;
+            }
+            if (state.isActive()) {
+                LOG.warn("S3 TVF label {} is {}; cancelling it before retry", label, state);
+                try {
+                    cancelLoad(label);
+                } catch (SQLException e) {
+                    // The load may finish between SHOW LOAD and CANCEL LOAD.
+                    LOG.warn(
+                            "Failed to cancel S3 TVF label {} (SQLState={}, errorCode={}); "
+                                    + "rechecking its load state",
+                            label,
+                            e.getSQLState(),
+                            e.getErrorCode());
+                }
+                state = getLoadState(label);
+                if (state == S3TvfLoadState.FINISHED || state == S3TvfLoadState.CANCELLED) {
+                    continue;
+                }
+            }
+            if (retries++ >= maxRetries) {
+                break;
+            }
+            state = getLoadState(label);
+        }
+        throw new DorisException(
+                "Unable to reconcile S3 TVF label " + label + " with state " + state);
+    }
+
+    private S3TvfLoadState getLoadState(String label) throws SQLException {
+        String sql =
+                "SHOW LOAD FROM "
+                        + quoteIdentifier(database)
+                        + " WHERE LABEL = "
+                        + quoteLiteral(label);
+        try (Statement statement = connection().createStatement();
+                ResultSet resultSet = statement.executeQuery(sql)) {
+            S3TvfLoadState resolvedState = S3TvfLoadState.NOT_FOUND;
+            while (resultSet.next()) {
+                S3TvfLoadState state = parseState(resultSet.getString("State"));
+                if (state == S3TvfLoadState.FINISHED) {
+                    return state;
+                }
+                if (state.isActive()
+                        || (state == S3TvfLoadState.CANCELLED && !resolvedState.isActive())
+                        || resolvedState == S3TvfLoadState.NOT_FOUND) {
+                    resolvedState = state;
+                }
+            }
+            return resolvedState;
+        }
+    }
+
+    private void cancelLoad(String label) throws SQLException {
+        String sql =
+                "CANCEL LOAD FROM "
+                        + quoteIdentifier(database)
+                        + " WHERE LABEL = "
+                        + quoteLiteral(label);
+        try (Statement statement = connection().createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private Connection connection() throws SQLException {
+        try {
+            return connectionProvider.getOrEstablishConnection();
+        } catch (Exception e) {
+            throw new SQLException("Unable to establish Doris JDBC connection", e);
+        }
+    }
+
+    private static S3TvfLoadState parseState(String value) {
+        if (value == null) {
+            return S3TvfLoadState.UNKNOWN;
+        }
+        try {
+            return S3TvfLoadState.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return S3TvfLoadState.UNKNOWN;
+        }
+    }
+
+    private static boolean isLabelAlreadyUsed(Throwable throwable, String label) {
+        String marker = "Label [" + label + "] has already been used";
+        Throwable current = throwable;
+        while (current != null) {
+            if (current.getMessage() != null && current.getMessage().contains(marker)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static DorisException failure(String label, Throwable cause) {
+        return new DorisException("Failed to commit S3 TVF label " + label, cause);
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoadState.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoadState.java
@@ -17,30 +17,19 @@
  * under the License.
  */
 
-package org.apache.doris.kafka.connector.writer.load;
+package org.apache.doris.kafka.connector.writer.s3;
 
-public enum LoadModel {
-    STREAM_LOAD("stream_load"),
+/** States returned by SHOW LOAD for an INSERT label. */
+enum S3TvfLoadState {
+    PENDING,
+    ETL,
+    LOADING,
+    FINISHED,
+    CANCELLED,
+    NOT_FOUND,
+    UNKNOWN;
 
-    COPY_INTO("copy_into"),
-
-    TVF("tvf");
-
-    private String name;
-
-    LoadModel(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public static LoadModel of(String name) {
-        return LoadModel.valueOf(name.toUpperCase());
-    }
-
-    public static String[] instances() {
-        return new String[] {STREAM_LOAD.name, COPY_INTO.name, TVF.name};
+    boolean isActive() {
+        return this == PENDING || this == ETL || this == LOADING;
     }
 }

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfRecordSerializer.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfRecordSerializer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.doris.kafka.connector.exception.DataFormatException;
+import org.apache.doris.kafka.connector.writer.LoadConstants;
+
+/** Normalizes processed records to the fixed JSON Lines schema used by S3 TVF. */
+public class S3TvfRecordSerializer {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectReader OBJECT_READER =
+            OBJECT_MAPPER.reader().with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+    private static final String TVF_DELETE_SIGN = "__doris_delete_sign__";
+
+    private final List<String> columns;
+    private final boolean deleteSignEnabled;
+
+    public S3TvfRecordSerializer(List<String> columns, boolean deleteSignEnabled) {
+        this.columns = columns;
+        this.deleteSignEnabled = deleteSignEnabled;
+    }
+
+    public String serialize(String processedRecord) {
+        return serializeRecord(processedRecord);
+    }
+
+    private String serializeRecord(String processedRecord) {
+        try {
+            JsonNode root = OBJECT_READER.readTree(processedRecord);
+            if (root == null || !root.isObject()) {
+                throw new DataFormatException("S3 TVF records must be JSON objects");
+            }
+            Map<String, JsonNode> normalized = new LinkedHashMap<>();
+            for (String column : columns) {
+                normalized.put(column, root.get(column));
+            }
+            if (deleteSignEnabled) {
+                JsonNode deleteSign = root.get(LoadConstants.DORIS_DELETE_SIGN);
+                if (deleteSign == null) {
+                    deleteSign = root.get(TVF_DELETE_SIGN);
+                }
+                normalized.put(
+                        TVF_DELETE_SIGN,
+                        deleteSign == null
+                                ? OBJECT_MAPPER
+                                        .getNodeFactory()
+                                        .textNode(LoadConstants.DORIS_DEL_FALSE)
+                                : deleteSign);
+            }
+            return OBJECT_MAPPER.writeValueAsString(normalized);
+        } catch (DataFormatException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DataFormatException("Failed to normalize an S3 TVF record", e);
+        }
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfSqlBuilder.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/S3TvfSqlBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import static org.apache.doris.kafka.connector.writer.s3.TvfSqlUtils.quoteIdentifier;
+import static org.apache.doris.kafka.connector.writer.s3.TvfSqlUtils.quoteLiteral;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import org.apache.doris.kafka.connector.cfg.S3TvfOptions;
+import org.apache.doris.kafka.connector.writer.LoadConstants;
+
+/** Builds explicit INSERT SELECT statements for staged S3 TVF files. */
+public class S3TvfSqlBuilder {
+    private final S3TvfOptions options;
+
+    public S3TvfSqlBuilder(S3TvfOptions options) {
+        this.options = options;
+    }
+
+    public String buildInsertSql(
+            String database,
+            String table,
+            String label,
+            List<String> objectKeys,
+            List<String> columns,
+            boolean deleteSignEnabled) {
+        if (objectKeys.isEmpty()) {
+            throw new IllegalArgumentException("S3 TVF load requires at least one file");
+        }
+        List<String> loadColumns = new ArrayList<>(columns);
+        if (deleteSignEnabled) {
+            loadColumns.add(LoadConstants.DORIS_DELETE_SIGN);
+        }
+        String columnSql = joinIdentifiers(loadColumns);
+        String uri = buildUri(objectKeys);
+        return "INSERT INTO "
+                + quoteIdentifier(database)
+                + "."
+                + quoteIdentifier(table)
+                + " WITH LABEL "
+                + quoteIdentifier(label)
+                + " ("
+                + columnSql
+                + ") SELECT "
+                + columnSql
+                + " FROM S3("
+                + property("uri", uri)
+                + ","
+                + property("s3.access_key", options.getAccessKey())
+                + ","
+                + property("s3.secret_key", options.getSecretKey())
+                + ","
+                + property("s3.region", options.getRegion())
+                + ","
+                + property("s3.endpoint", options.getEndpoint())
+                + ","
+                + property("format", "json")
+                + ","
+                + property("read_json_by_line", "true")
+                + ","
+                + property("use_path_style", Boolean.toString(options.isPathStyleAccess()))
+                + ")";
+    }
+
+    private String buildUri(List<String> objectKeys) {
+        if (objectKeys.size() == 1) {
+            return "s3://" + options.getBucket() + "/" + objectKeys.get(0);
+        }
+        return "s3://" + options.getBucket() + "/{" + String.join(",", objectKeys) + "}";
+    }
+
+    private static String joinIdentifiers(List<String> identifiers) {
+        StringJoiner joiner = new StringJoiner(",");
+        for (String identifier : identifiers) {
+            joiner.add(quoteIdentifier(identifier));
+        }
+        return joiner.toString();
+    }
+
+    private static String property(String key, String value) {
+        return quoteLiteral(key) + " = " + quoteLiteral(value);
+    }
+}

--- a/src/main/java/org/apache/doris/kafka/connector/writer/s3/TvfSqlUtils.java
+++ b/src/main/java/org/apache/doris/kafka/connector/writer/s3/TvfSqlUtils.java
@@ -17,30 +17,23 @@
  * under the License.
  */
 
-package org.apache.doris.kafka.connector.writer.load;
+package org.apache.doris.kafka.connector.writer.s3;
 
-public enum LoadModel {
-    STREAM_LOAD("stream_load"),
+/** SQL quoting utilities for the S3 TVF write path. */
+final class TvfSqlUtils {
+    private TvfSqlUtils() {}
 
-    COPY_INTO("copy_into"),
-
-    TVF("tvf");
-
-    private String name;
-
-    LoadModel(String name) {
-        this.name = name;
+    static String quoteIdentifier(String value) {
+        return "`" + value.replace("`", "``") + "`";
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public static LoadModel of(String name) {
-        return LoadModel.valueOf(name.toUpperCase());
-    }
-
-    public static String[] instances() {
-        return new String[] {STREAM_LOAD.name, COPY_INTO.name, TVF.name};
+    static String quoteLiteral(String value) {
+        String escaped =
+                value.replace("\\", "\\\\")
+                        .replace("'", "\\'")
+                        .replace("\u0000", "\\0")
+                        .replace("\n", "\\n")
+                        .replace("\r", "\\r");
+        return "'" + escaped + "'";
     }
 }

--- a/src/test/java/org/apache/doris/kafka/connector/cfg/S3TvfOptionsTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/cfg/S3TvfOptionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.cfg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3TvfOptionsTest {
+
+    @Test
+    public void testBuildOptions() {
+        S3TvfOptions options =
+                S3TvfOptions.builder()
+                        .setEndpoint("https://s3.example.com")
+                        .setRegion("us-east-1")
+                        .setBucket("staging")
+                        .setPrefix("kafka/orders")
+                        .setAccessKey("access-key")
+                        .setSecretKey("secret-key")
+                        .setPathStyleAccess(true)
+                        .build();
+
+        Assert.assertEquals("https://s3.example.com", options.getEndpoint());
+        Assert.assertEquals("us-east-1", options.getRegion());
+        Assert.assertEquals("staging", options.getBucket());
+        Assert.assertEquals("kafka/orders", options.getPrefix());
+        Assert.assertEquals("access-key", options.getAccessKey());
+        Assert.assertEquals("secret-key", options.getSecretKey());
+        Assert.assertTrue(options.isPathStyleAccess());
+        Assert.assertFalse(options.toString().contains("access-key"));
+        Assert.assertFalse(options.toString().contains("secret-key"));
+    }
+
+    @Test
+    public void testRejectsAllGlobCharactersInPrefix() {
+        for (String character : new String[] {"*", "?", "[", "]", "{", "}", ",", "\\"}) {
+            try {
+                validBuilder().setPrefix("kafka/" + character + "/orders").build();
+                Assert.fail("Expected prefix containing '" + character + "' to be rejected");
+            } catch (IllegalArgumentException expected) {
+                // Expected.
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRejectsInvalidEndpoint() {
+        validBuilder().setEndpoint("s3.example.com").build();
+    }
+
+    private static S3TvfOptions.Builder validBuilder() {
+        return S3TvfOptions.builder()
+                .setEndpoint("https://s3.example.com")
+                .setRegion("us-east-1")
+                .setBucket("staging")
+                .setPrefix("kafka/orders")
+                .setAccessKey("access-key")
+                .setSecretKey("secret-key");
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/cfg/TestDorisOptions.java
+++ b/src/test/java/org/apache/doris/kafka/connector/cfg/TestDorisOptions.java
@@ -134,4 +134,25 @@ public class TestDorisOptions {
         Assert.assertEquals("certs/ca.pem", tlsOptions.getCaCertificatePath());
         Assert.assertTrue(tlsOptions.isSkipHostnameVerification());
     }
+
+    @Test
+    public void testS3TvfOptionsAndSessionVariables() {
+        Map<String, String> config = TestDorisSinkConnectorConfig.getS3TvfConfig();
+        config.put("task_id", "2");
+        config.put("sink.properties.enable_unique_key_partial_update", "true");
+        config.put("sink.properties.partial_update_new_key_behavior", "ERROR");
+        config.put("sink.properties.format", "json");
+
+        DorisOptions options = new DorisOptions(config);
+
+        Assert.assertEquals(2, options.getTaskId());
+        Assert.assertEquals("staging", options.getS3TvfOptions().getBucket());
+        Assert.assertEquals(Arrays.asList("id", "name"), options.getTvfColumns());
+        Assert.assertEquals(
+                "true", options.getSessionVariables().get("enable_unique_key_partial_update"));
+        Assert.assertEquals(
+                "ERROR", options.getSessionVariables().get("partial_update_new_key_behavior"));
+        Assert.assertFalse(options.getSessionVariables().containsKey("format"));
+        Assert.assertFalse(options.getSessionVariables().containsKey("compress_type"));
+    }
 }

--- a/src/test/java/org/apache/doris/kafka/connector/cfg/TestDorisSinkConnectorConfig.java
+++ b/src/test/java/org/apache/doris/kafka/connector/cfg/TestDorisSinkConnectorConfig.java
@@ -263,6 +263,61 @@ public class TestDorisSinkConnectorConfig {
     }
 
     @Test
+    public void testS3TvfConfig() {
+        ConfigCheckUtils.validateConfig(getS3TvfConfig());
+    }
+
+    @Test(expected = DorisException.class)
+    public void testRejectLegacyS3TvfLoadModel() {
+        Map<String, String> config = getS3TvfConfig();
+        config.put(DorisSinkConnectorConfig.LOAD_MODEL, "s3_tvf");
+        ConfigCheckUtils.validateConfig(config);
+    }
+
+    @Test
+    public void testTvfConfigDoesNotExposeCleanupOption() {
+        Assert.assertFalse(
+                DorisSinkConnectorConfig.newConfigDef()
+                        .configKeys()
+                        .containsKey("sink.s3.cleanup.enabled"));
+    }
+
+    @Test(expected = DorisException.class)
+    public void testS3TvfRequiresEndpoint() {
+        Map<String, String> config = getS3TvfConfig();
+        config.remove(DorisSinkConnectorConfig.SINK_S3_ENDPOINT);
+        ConfigCheckUtils.validateConfig(config);
+    }
+
+    @Test(expected = DorisException.class)
+    public void testS3TvfRequiresColumns() {
+        Map<String, String> config = getS3TvfConfig();
+        config.remove(DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX + "columns");
+        ConfigCheckUtils.validateConfig(config);
+    }
+
+    @Test(expected = DorisException.class)
+    public void testS3TvfRejectsInvalidPathStyleAccess() {
+        Map<String, String> config = getS3TvfConfig();
+        config.put(DorisSinkConnectorConfig.SINK_S3_PATH_STYLE_ACCESS, "yes");
+        ConfigCheckUtils.validateConfig(config);
+    }
+
+    @Test(expected = DorisException.class)
+    public void testS3TvfRequiresCombineFlush() {
+        Map<String, String> config = getS3TvfConfig();
+        config.put(DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH, "false");
+        ConfigCheckUtils.validateConfig(config);
+    }
+
+    @Test(expected = DorisException.class)
+    public void testS3TvfRejectsExactlyOnce() {
+        Map<String, String> config = getS3TvfConfig();
+        config.put(DorisSinkConnectorConfig.DELIVERY_GUARANTEE, "exactly_once");
+        ConfigCheckUtils.validateConfig(config);
+    }
+
+    @Test
     public void testDeliveryGuarantee() {
         Map<String, String> config = getConfig();
         ConfigCheckUtils.validateConfig(config);
@@ -359,6 +414,21 @@ public class TestDorisSinkConnectorConfig {
         Map<String, String> config = (Map) loadProps;
         config.putAll(customConfig);
         return new DorisOptions(config);
+    }
+
+    public static Map<String, String> getS3TvfConfig() {
+        Map<String, String> config = getConfig();
+        config.put(DorisSinkConnectorConfig.LOAD_MODEL, "tvf");
+        config.put(DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH, "true");
+        config.put(DorisSinkConnectorConfig.DELIVERY_GUARANTEE, "at_least_once");
+        config.put(DorisSinkConnectorConfig.SINK_S3_ENDPOINT, "https://s3.example.com");
+        config.put(DorisSinkConnectorConfig.SINK_S3_REGION, "us-east-1");
+        config.put(DorisSinkConnectorConfig.SINK_S3_BUCKET, "staging");
+        config.put(DorisSinkConnectorConfig.SINK_S3_PREFIX, "kafka/orders");
+        config.put(DorisSinkConnectorConfig.SINK_S3_ACCESS_KEY, "access-key");
+        config.put(DorisSinkConnectorConfig.SINK_S3_SECRET_KEY, "secret-key");
+        config.put(DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX + "columns", "id,name");
+        return config;
     }
 
     @Test(expected = DorisException.class)

--- a/src/test/java/org/apache/doris/kafka/connector/cfg/TvfColumnUtilsTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/cfg/TvfColumnUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.cfg;
+
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TvfColumnUtilsTest {
+
+    @Test
+    public void testResolveFixedPhysicalColumns() {
+        Assert.assertEquals(
+                Arrays.asList("id", "order name", "create_time"),
+                TvfColumnUtils.resolveColumns("id,`order name`,create_time"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRejectMissingColumns() {
+        TvfColumnUtils.resolveColumns(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRejectEmptyColumn() {
+        TvfColumnUtils.resolveColumns("id,,name");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRejectDuplicateColumn() {
+        TvfColumnUtils.resolveColumns("id,id");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRejectStreamLoadColumnExpression() {
+        TvfColumnUtils.resolveColumns("id,total=price*quantity");
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/e2e/doris/DorisContainerServiceImpl.java
+++ b/src/test/java/org/apache/doris/kafka/connector/e2e/doris/DorisContainerServiceImpl.java
@@ -49,7 +49,8 @@ import org.testcontainers.utility.MountableFile;
 
 public class DorisContainerServiceImpl implements DorisContainerService {
     protected static final Logger LOG = LoggerFactory.getLogger(DorisContainerServiceImpl.class);
-    protected static final String DORIS_DOCKER_IMAGE = "apache/doris:doris-all-in-one-2.1.0";
+    protected static final String DORIS_DOCKER_IMAGE =
+            System.getProperty("image", "jnsimba/doris-all-in-one:4.1.3");
     private static final String DRIVER_JAR =
             "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar";
     protected static final String JDBC_URL = "jdbc:mysql://%s:9030";

--- a/src/test/java/org/apache/doris/kafka/connector/e2e/sink/S3TvfSinkITCase.java
+++ b/src/test/java/org/apache/doris/kafka/connector/e2e/sink/S3TvfSinkITCase.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.e2e.sink;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
+import org.apache.doris.kafka.connector.e2e.sink.stringconverter.AbstractStringE2ESinkTest;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+
+public class S3TvfSinkITCase extends AbstractStringE2ESinkTest {
+    private static final String MINIO_IMAGE = "minio/minio:RELEASE.2024-10-13T13-34-11Z";
+    private static final int MINIO_PORT = 9000;
+    private static final String ACCESS_KEY = "minioadmin";
+    private static final String SECRET_KEY = "minioadmin";
+    private static final String REGION = "us-east-1";
+    private static final String BUCKET = "doris-kafka-connector-it";
+    private static final String DATABASE = "s3_tvf_it";
+    private static final String JSON_TOPIC = "s3_tvf_json_topic";
+    private static final String JSON_TABLE = "s3_tvf_json_table";
+    private static final String JSON_CONNECTOR = "s3_tvf_json_connector";
+    private static final String JSON_LABEL_PREFIX = "s3_tvf_json";
+    private static final String JSON_S3_PREFIX = "it/json";
+    private static final String DEBEZIUM_TOPIC = "s3_tvf_debezium_topic";
+    private static final String DEBEZIUM_TABLE = "s3_tvf_debezium_table";
+    private static final String DEBEZIUM_CONNECTOR = "s3_tvf_debezium_connector";
+    private static final String DEBEZIUM_S3_PREFIX = "it/debezium";
+    private static final long WAIT_TIMEOUT_NANOS = TimeUnit.MINUTES.toNanos(2);
+
+    private static GenericContainer<?> minioContainer;
+    private static S3Client s3Client;
+    private static String s3Endpoint;
+
+    private String registeredConnector;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        initServer();
+        initProducer();
+        startMinio();
+        createDatabase(DATABASE);
+    }
+
+    @After
+    public void unregisterConnector() {
+        if (registeredConnector != null) {
+            kafkaContainerService.deleteKafkaConnector(registeredConnector);
+            registeredConnector = null;
+        }
+    }
+
+    @AfterClass
+    public static void stopMinio() {
+        if (s3Client != null) {
+            s3Client.close();
+        }
+        if (minioContainer != null) {
+            minioContainer.close();
+        }
+    }
+
+    @Test
+    public void testJsonRecordsCreateMultipleTvfFiles() throws Exception {
+        resetTable(JSON_TABLE, false);
+        produceMsg2Kafka(JSON_TOPIC, "{\"id\":1,\"name\":\"alice\",\"age\":20}");
+        produceMsg2Kafka(JSON_TOPIC, "{\"id\":2,\"name\":\"bob\",\"age\":30}");
+        produceMsg2Kafka(JSON_TOPIC, "{\"id\":3,\"name\":\"carol\",\"age\":40}");
+
+        registerConnector(
+                JSON_CONNECTOR,
+                connectorConfig(
+                        JSON_CONNECTOR,
+                        JSON_TOPIC,
+                        JSON_TABLE,
+                        JSON_LABEL_PREFIX,
+                        JSON_S3_PREFIX,
+                        "org.apache.kafka.connect.storage.StringConverter",
+                        "normal",
+                        false));
+
+        String query =
+                String.format("SELECT id,name,age FROM %s.%s ORDER BY id", DATABASE, JSON_TABLE);
+        waitForRows(
+                JSON_CONNECTOR, query, Arrays.asList("1,alice,20", "2,bob,30", "3,carol,40"), 3);
+
+        List<String> objectKeys = waitForObjectCount(JSON_CONNECTOR, JSON_S3_PREFIX + "/", 3);
+        assertJsonObjectNames(objectKeys);
+    }
+
+    @Test
+    public void testDebeziumInsertUpdateDeleteThroughTvf() throws Exception {
+        resetTable(DEBEZIUM_TABLE, true);
+        registerConnector(
+                DEBEZIUM_CONNECTOR,
+                connectorConfig(
+                        DEBEZIUM_CONNECTOR,
+                        DEBEZIUM_TOPIC,
+                        DEBEZIUM_TABLE,
+                        "s3_tvf_debezium",
+                        DEBEZIUM_S3_PREFIX,
+                        "org.apache.kafka.connect.json.JsonConverter",
+                        "debezium_ingestion",
+                        true));
+
+        String query =
+                String.format(
+                        "SELECT id,name,age FROM %s.%s ORDER BY id", DATABASE, DEBEZIUM_TABLE);
+        produceMsg2Kafka(DEBEZIUM_TOPIC, debeziumEvent(null, row(1, "alice", 20), "c"));
+        waitForRows(DEBEZIUM_CONNECTOR, query, Collections.singletonList("1,alice,20"), 3);
+
+        produceMsg2Kafka(
+                DEBEZIUM_TOPIC, debeziumEvent(row(1, "alice", 20), row(1, "alice", 21), "u"));
+        waitForRows(DEBEZIUM_CONNECTOR, query, Collections.singletonList("1,alice,21"), 3);
+
+        produceMsg2Kafka(DEBEZIUM_TOPIC, debeziumEvent(row(1, "alice", 21), null, "d"));
+        waitForRows(DEBEZIUM_CONNECTOR, query, Collections.emptyList(), 3);
+    }
+
+    private static void startMinio() throws Exception {
+        minioContainer =
+                new GenericContainer<>(DockerImageName.parse(MINIO_IMAGE))
+                        .withEnv("MINIO_ROOT_USER", ACCESS_KEY)
+                        .withEnv("MINIO_ROOT_PASSWORD", SECRET_KEY)
+                        .withCommand("server", "/data", "--address", ":" + MINIO_PORT)
+                        .withExposedPorts(MINIO_PORT)
+                        .waitingFor(
+                                Wait.forHttp("/minio/health/live")
+                                        .forPort(MINIO_PORT)
+                                        .withStartupTimeout(Duration.ofMinutes(2)));
+        minioContainer.start();
+
+        s3Endpoint =
+                "http://" + resolveEndpointHost() + ":" + minioContainer.getMappedPort(MINIO_PORT);
+        s3Client = createS3Client(s3Endpoint);
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+    }
+
+    private static S3Client createS3Client(String endpoint) {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.of(REGION))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
+                .serviceConfiguration(
+                        S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .build();
+    }
+
+    private static String resolveEndpointHost() throws Exception {
+        String dockerHost = DockerClientFactory.instance().dockerHostIpAddress();
+        for (InetAddress address : InetAddress.getAllByName(dockerHost)) {
+            if (isUsableEndpointAddress(address)) {
+                return address.getHostAddress();
+            }
+        }
+
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+            if (!networkInterface.isUp() || networkInterface.isLoopback()) {
+                continue;
+            }
+            Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+            while (addresses.hasMoreElements()) {
+                InetAddress address = addresses.nextElement();
+                if (isUsableEndpointAddress(address)) {
+                    return address.getHostAddress();
+                }
+            }
+        }
+        throw new IllegalStateException("Unable to resolve a non-loopback IPv4 S3 endpoint");
+    }
+
+    private static boolean isUsableEndpointAddress(InetAddress address) {
+        return address instanceof Inet4Address
+                && !address.isAnyLocalAddress()
+                && !address.isLoopbackAddress();
+    }
+
+    private void resetTable(String table, boolean uniqueKey) {
+        executeSql("DROP TABLE IF EXISTS " + DATABASE + "." + table);
+        String keyModel = uniqueKey ? "UNIQUE KEY(id)" : "DUPLICATE KEY(id)";
+        String tableProperties =
+                uniqueKey
+                        ? "PROPERTIES (\"replication_num\" = \"1\", "
+                                + "\"enable_unique_key_merge_on_write\" = \"true\")"
+                        : "PROPERTIES (\"replication_num\" = \"1\")";
+        createTable(
+                "CREATE TABLE "
+                        + DATABASE
+                        + "."
+                        + table
+                        + " (id INT, name VARCHAR(64), age INT) "
+                        + keyModel
+                        + " DISTRIBUTED BY HASH(id) BUCKETS 1 "
+                        + tableProperties);
+    }
+
+    private String connectorConfig(
+            String connectorName,
+            String topic,
+            String table,
+            String labelPrefix,
+            String s3Prefix,
+            String valueConverter,
+            String converterMode,
+            boolean enableDelete)
+            throws Exception {
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put(NAME, connectorName);
+        ObjectNode config = root.putObject(CONFIG);
+        config.put("connector.class", "org.apache.doris.kafka.connector.DorisSinkConnector");
+        config.put("topics", topic);
+        config.put("tasks.max", "1");
+        config.put("doris.topic2table.map", topic + ":" + table);
+        config.put("buffer.count.records", "100");
+        config.put("buffer.flush.time", "1");
+        config.put("buffer.size.bytes", "1");
+        config.put("label.prefix", labelPrefix);
+        config.put(DorisSinkConnectorConfig.DORIS_URLS, "127.0.0.1");
+        config.put(DorisSinkConnectorConfig.DORIS_HTTP_PORT, "8030");
+        config.put(DorisSinkConnectorConfig.DORIS_QUERY_PORT, "9030");
+        config.put(DorisSinkConnectorConfig.DORIS_USER, "root");
+        config.put(DorisSinkConnectorConfig.DORIS_PASSWORD, "");
+        config.put(DorisSinkConnectorConfig.DORIS_DATABASE, DATABASE);
+        config.put("load.model", "tvf");
+        config.put("enable.combine.flush", "true");
+        config.put("delivery.guarantee", "at_least_once");
+        config.put("enable.delete", Boolean.toString(enableDelete));
+        config.put("converter.mode", converterMode);
+        config.put("key.converter", valueConverter);
+        config.put("value.converter", valueConverter);
+        if ("org.apache.kafka.connect.json.JsonConverter".equals(valueConverter)) {
+            config.put("value.converter.schemas.enable", "true");
+        }
+        config.put("sink.properties.columns", "id,name,age");
+        config.put("sink.s3.endpoint", s3Endpoint);
+        config.put("sink.s3.region", REGION);
+        config.put("sink.s3.bucket", BUCKET);
+        config.put("sink.s3.prefix", s3Prefix);
+        config.put("sink.s3.access-key", ACCESS_KEY);
+        config.put("sink.s3.secret-key", SECRET_KEY);
+        config.put("sink.s3.path-style-access", "true");
+        return configureDorisConnector(objectMapper.writeValueAsString(root));
+    }
+
+    private void registerConnector(String name, String config) throws Exception {
+        registeredConnector = name;
+        kafkaContainerService.registerKafkaConnector(name, config);
+    }
+
+    private static ObjectNode row(int id, String name, int age) {
+        ObjectNode row = objectMapper.createObjectNode();
+        row.put("id", id);
+        row.put("name", name);
+        row.put("age", age);
+        return row;
+    }
+
+    private static String debeziumEvent(ObjectNode before, ObjectNode after, String operation)
+            throws Exception {
+        ObjectNode rowSchema = objectMapper.createObjectNode();
+        rowSchema.put("type", "struct");
+        rowSchema.put("optional", true);
+        rowSchema.put("name", "s3.tvf.it.Customer.Value");
+        ArrayNode rowFields = rowSchema.putArray("fields");
+        rowFields.add(fieldSchema("int32", false, "id"));
+        rowFields.add(fieldSchema("string", false, "name"));
+        rowFields.add(fieldSchema("int32", false, "age"));
+
+        ObjectNode envelopeSchema = objectMapper.createObjectNode();
+        envelopeSchema.put("type", "struct");
+        envelopeSchema.put("optional", false);
+        envelopeSchema.put("name", "s3.tvf.it.Customer.Envelope");
+        ArrayNode envelopeFields = envelopeSchema.putArray("fields");
+        ObjectNode beforeSchema = rowSchema.deepCopy();
+        beforeSchema.put("field", "before");
+        envelopeFields.add(beforeSchema);
+        ObjectNode afterSchema = rowSchema.deepCopy();
+        afterSchema.put("field", "after");
+        envelopeFields.add(afterSchema);
+        envelopeFields.add(fieldSchema("string", false, "op"));
+
+        ObjectNode payload = objectMapper.createObjectNode();
+        if (before == null) {
+            payload.putNull("before");
+        } else {
+            payload.set("before", before);
+        }
+        if (after == null) {
+            payload.putNull("after");
+        } else {
+            payload.set("after", after);
+        }
+        payload.put("op", operation);
+
+        ObjectNode event = objectMapper.createObjectNode();
+        event.set("schema", envelopeSchema);
+        event.set("payload", payload);
+        return objectMapper.writeValueAsString(event);
+    }
+
+    private static ObjectNode fieldSchema(String type, boolean optional, String field) {
+        ObjectNode schema = objectMapper.createObjectNode();
+        schema.put("type", type);
+        schema.put("optional", optional);
+        schema.put("field", field);
+        return schema;
+    }
+
+    private void waitForRows(
+            String connectorName, String query, List<String> expected, int columnCount)
+            throws Exception {
+        long deadline = System.nanoTime() + WAIT_TIMEOUT_NANOS;
+        List<String> actual = Collections.emptyList();
+        SQLException lastError = null;
+        while (System.nanoTime() < deadline) {
+            assertConnectorIsHealthy(connectorName);
+            try {
+                actual = queryRows(query, columnCount);
+                lastError = null;
+                if (expected.equals(actual)) {
+                    return;
+                }
+            } catch (SQLException e) {
+                lastError = e;
+            }
+            Thread.sleep(2000);
+        }
+        AssertionError error =
+                new AssertionError(
+                        "Timed out waiting for Doris rows. expected="
+                                + expected
+                                + ", actual="
+                                + actual);
+        if (lastError != null) {
+            error.initCause(lastError);
+        }
+        throw error;
+    }
+
+    private static List<String> queryRows(String query, int columnCount) throws SQLException {
+        List<String> rows = new ArrayList<>();
+        try (Connection connection = getJdbcConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(query)) {
+            while (resultSet.next()) {
+                List<String> values = new ArrayList<>();
+                for (int index = 1; index <= columnCount; index++) {
+                    Object value = resultSet.getObject(index);
+                    values.add(value == null ? "null" : value.toString());
+                }
+                rows.add(StringUtils.join(values, ","));
+            }
+        }
+        return rows;
+    }
+
+    private List<String> waitForObjectCount(String connectorName, String prefix, int expectedCount)
+            throws Exception {
+        long deadline = System.nanoTime() + WAIT_TIMEOUT_NANOS;
+        List<String> objectKeys = Collections.emptyList();
+        while (System.nanoTime() < deadline) {
+            assertConnectorIsHealthy(connectorName);
+            objectKeys = listObjectKeys(prefix);
+            if (objectKeys.size() >= expectedCount) {
+                Assert.assertEquals(expectedCount, objectKeys.size());
+                return objectKeys;
+            }
+            Thread.sleep(2000);
+        }
+        throw new AssertionError(
+                "Timed out waiting for "
+                        + expectedCount
+                        + " S3 objects under "
+                        + prefix
+                        + "; found "
+                        + objectKeys);
+    }
+
+    private static List<String> listObjectKeys(String prefix) {
+        return s3Client
+                .listObjectsV2(ListObjectsV2Request.builder().bucket(BUCKET).prefix(prefix).build())
+                .contents().stream()
+                .map(object -> object.key())
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    private void assertConnectorIsHealthy(String connectorName) {
+        String state = kafkaContainerService.getConnectorTaskStatus(connectorName);
+        Assert.assertFalse(
+                "Kafka Connect task failed for " + connectorName, "FAILED".equalsIgnoreCase(state));
+    }
+
+    private static void assertJsonObjectNames(List<String> objectKeys) {
+        Pattern fileNamePattern =
+                Pattern.compile(
+                        "^"
+                                + Pattern.quote(
+                                        JSON_LABEL_PREFIX + "_" + DATABASE + "_" + JSON_TABLE + "_")
+                                + "([0-9a-f]{32})_0_([0-9]+)\\.json$");
+        Set<String> batchUuids = new HashSet<>();
+        Set<String> fileNumbers = new HashSet<>();
+        for (String objectKey : objectKeys) {
+            String fileName = objectKey.substring(objectKey.lastIndexOf('/') + 1);
+            Matcher matcher = fileNamePattern.matcher(fileName);
+            Assert.assertTrue("Unexpected S3 TVF object name: " + objectKey, matcher.matches());
+            batchUuids.add(matcher.group(1));
+            fileNumbers.add(matcher.group(2));
+        }
+        Assert.assertEquals(1, batchUuids.size());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("0", "1", "2")), fileNumbers);
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/service/DorisCombinedSinkServiceTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/service/DorisCombinedSinkServiceTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.service;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
+import org.apache.doris.kafka.connector.exception.DorisException;
+import org.apache.doris.kafka.connector.writer.AsyncS3TvfWriter;
+import org.apache.doris.kafka.connector.writer.DorisWriter;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DorisCombinedSinkServiceTest {
+    @Test
+    public void testCreatesOneS3WriterForAllPartitionsOfTopicTable() throws Exception {
+        DorisCombinedSinkService service = service();
+        service.startTask("orders", new TopicPartition("orders-topic", 0));
+        service.startTask("orders", new TopicPartition("orders-topic", 1));
+
+        Assert.assertEquals(1, service.writer.size());
+        Assert.assertTrue(service.writer.values().iterator().next() instanceof AsyncS3TvfWriter);
+        service.close();
+    }
+
+    @Test
+    public void testCommitFlushesAllWriters() throws Exception {
+        DorisCombinedSinkService service = service();
+        DorisWriter firstWriter = mock(DorisWriter.class);
+        DorisWriter secondWriter = mock(DorisWriter.class);
+        service.writer.put("first", firstWriter);
+        service.writer.put("second", secondWriter);
+
+        service.commit(Collections.emptyMap());
+
+        verify(firstWriter).commitFlush();
+        verify(secondWriter).commitFlush();
+        service.close();
+    }
+
+    @Test
+    public void testCommitPropagatesWriterFailure() throws Exception {
+        DorisCombinedSinkService service = service();
+        DorisWriter writer = mock(DorisWriter.class);
+        doThrow(new DorisException("load failed")).when(writer).commitFlush();
+        service.writer.put("writer", writer);
+        TopicPartition partition = new TopicPartition("orders-topic", 0);
+        Map<TopicPartition, OffsetAndMetadata> offsets =
+                Collections.singletonMap(partition, new OffsetAndMetadata(6));
+
+        Assert.assertThrows(DorisException.class, () -> service.commit(offsets));
+        service.close();
+    }
+
+    @Test
+    public void testCombinedInsertDoesNotUseTimeBasedFlush() throws Exception {
+        DorisCombinedSinkService service = service();
+        DorisWriter writer = mock(DorisWriter.class);
+        when(writer.shouldFlush()).thenReturn(true);
+        service.writer.put("orders-topic", writer);
+        SinkRecord record =
+                new SinkRecord(
+                        "orders-topic",
+                        0,
+                        Schema.OPTIONAL_STRING_SCHEMA,
+                        "key",
+                        Schema.OPTIONAL_STRING_SCHEMA,
+                        "{\"id\":1,\"name\":\"first\"}",
+                        5);
+
+        service.insert(Collections.singleton(record));
+
+        verify(writer).insert(record);
+        verify(writer, never()).shouldFlush();
+        verify(writer, never()).flushBuffer();
+        service.close();
+    }
+
+    private static DorisCombinedSinkService service() throws IOException {
+        InputStream stream =
+                DorisCombinedSinkServiceTest.class
+                        .getClassLoader()
+                        .getResourceAsStream("doris-connector-sink.properties");
+        Properties properties = new Properties();
+        properties.load(stream);
+        DorisSinkConnectorConfig.setDefaultValues((Map) properties);
+        properties.put("task_id", "7");
+        properties.put(DorisSinkConnectorConfig.NAME, "connector");
+        properties.put(DorisSinkConnectorConfig.DORIS_DATABASE, "demo");
+        properties.put(DorisSinkConnectorConfig.JMX_OPT, "false");
+        properties.put(DorisSinkConnectorConfig.TOPICS_TABLES_MAP, "orders-topic:orders");
+        properties.put(DorisSinkConnectorConfig.LOAD_MODEL, "tvf");
+        properties.put(DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH, "true");
+        properties.put(DorisSinkConnectorConfig.DELIVERY_GUARANTEE, "at_least_once");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_ENDPOINT, "https://s3.example.com");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_REGION, "us-east-1");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_BUCKET, "staging");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_PREFIX, "objects");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_ACCESS_KEY, "access-key");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_SECRET_KEY, "secret-key");
+        properties.put(DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX + "columns", "id,name");
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        when(context.assignment())
+                .thenReturn(Collections.singleton(new TopicPartition("orders-topic", 0)));
+        return new DorisCombinedSinkService((Map) properties, context);
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriterTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriterTest.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.doris.kafka.connector.cfg.DorisOptions;
+import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
+import org.apache.doris.kafka.connector.connection.ConnectionProvider;
+import org.apache.doris.kafka.connector.converter.RecordService;
+import org.apache.doris.kafka.connector.exception.DorisException;
+import org.apache.doris.kafka.connector.metrics.DorisConnectMonitor;
+import org.apache.doris.kafka.connector.service.DorisSystemService;
+import org.apache.doris.kafka.connector.writer.s3.S3ObjectStore;
+import org.apache.doris.kafka.connector.writer.s3.S3TvfLoad;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class AsyncS3TvfWriterTest {
+    private static final String BATCH_UUID = "550e8400-e29b-41d4-a716-446655440000";
+    private static final String COMPACT_UUID = "550e8400e29b41d4a716446655440000";
+
+    @Test
+    public void testUsesTaskIdAndOneBatchLabelForAllFiles() throws Exception {
+        DorisOptions options = options(1024, 1);
+        RecordingObjectStore store = new RecordingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord first = TestRecordBuffer.newSinkRecord("ignored", 1);
+        SinkRecord second = TestRecordBuffer.newSinkRecord("ignored", 2);
+        when(records.getProcessedRecord(first)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        when(records.getProcessedRecord(second)).thenReturn("{\"id\":2,\"name\":\"second\"}");
+
+        AsyncS3TvfWriter writer = writer(options, store, load, records);
+        writer.insert(first);
+        writer.insert(second);
+        writer.commitFlush();
+
+        String label = "tvf_demo_orders_" + COMPACT_UUID;
+        String directory = "objects/tvf/demo_orders/" + COMPACT_UUID + "/";
+        Assert.assertEquals(2, store.objects.size());
+        Assert.assertTrue(store.objects.containsKey(directory + label + "_7_0.json"));
+        Assert.assertTrue(store.objects.containsKey(directory + label + "_7_1.json"));
+
+        ArgumentCaptor<List> objectKeys = ArgumentCaptor.forClass(List.class);
+        verify(load).load(org.mockito.ArgumentMatchers.eq(label), objectKeys.capture());
+        Assert.assertEquals(
+                Arrays.asList(directory + label + "_7_0.json", directory + label + "_7_1.json"),
+                objectKeys.getValue());
+        writer.close();
+    }
+
+    @Test
+    public void testCommitFlushWritesResidualBufferAndNormalizesRows() throws Exception {
+        DorisOptions options = options(1024, 100);
+        RecordingObjectStore store = new RecordingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord record = TestRecordBuffer.newSinkRecord("ignored", 1);
+        when(records.getProcessedRecord(record)).thenReturn("{\"id\":1,\"extra\":\"drop\"}");
+
+        AsyncS3TvfWriter writer = writer(options, store, load, records);
+        writer.insert(record);
+        Assert.assertTrue(store.objects.isEmpty());
+
+        writer.commitFlush();
+
+        Assert.assertEquals(1, store.objects.size());
+        String content =
+                new String(store.objects.values().iterator().next(), StandardCharsets.UTF_8);
+        Assert.assertEquals("{\"id\":1,\"name\":null}\n", content);
+        verify(load).load(anyString(), anyList());
+        writer.close();
+    }
+
+    @Test
+    public void testSizeThresholdSubmitsFileBeforeCommit() throws Exception {
+        DorisOptions options = options(10, 100);
+        BlockingObjectStore store = new BlockingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord record = TestRecordBuffer.newSinkRecord("ignored", 1);
+        when(records.getProcessedRecord(record)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        AsyncS3TvfWriter writer = writer(options, store, load, records);
+
+        try {
+            writer.insert(record);
+
+            Assert.assertTrue(store.uploadStarted.await(5, TimeUnit.SECONDS));
+            Assert.assertTrue(store.objects.isEmpty());
+            verify(load, never()).load(anyString(), anyList());
+
+            store.continueUpload.countDown();
+            writer.commitFlush();
+
+            Assert.assertEquals(1, store.objects.size());
+            verify(load).load(anyString(), anyList());
+        } finally {
+            store.continueUpload.countDown();
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testSizeThresholdFlushesAfterAppendingWholeRecord() throws Exception {
+        DorisOptions options = options(30, 100);
+        RecordingObjectStore store = new RecordingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord first = TestRecordBuffer.newSinkRecord("ignored", 1);
+        SinkRecord second = TestRecordBuffer.newSinkRecord("ignored", 2);
+        when(records.getProcessedRecord(first)).thenReturn("{\"id\":1,\"name\":\"a\"}");
+        when(records.getProcessedRecord(second)).thenReturn("{\"id\":2,\"name\":\"b\"}");
+        AsyncS3TvfWriter writer = writer(options, store, load, records);
+
+        try {
+            writer.insert(first);
+            writer.insert(second);
+            writer.commitFlush();
+
+            Assert.assertEquals(1, store.objects.size());
+            Assert.assertEquals(
+                    "{\"id\":1,\"name\":\"a\"}\n{\"id\":2,\"name\":\"b\"}\n",
+                    new String(store.objects.values().iterator().next(), StandardCharsets.UTF_8));
+        } finally {
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testEmptyCommitDoesNotCreateFileOrLoad() throws Exception {
+        RecordingObjectStore store = new RecordingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        AsyncS3TvfWriter writer =
+                writer(options(1024, 100), store, load, mock(RecordService.class));
+
+        writer.commitFlush();
+
+        Assert.assertTrue(store.objects.isEmpty());
+        verify(load, never()).load(anyString(), anyList());
+        writer.close();
+    }
+
+    @Test(expected = DorisException.class)
+    public void testUploadFailurePreventsLoad() throws Exception {
+        RecordingObjectStore store = new RecordingObjectStore();
+        store.putFailure = new IOException("upload failed");
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord record = TestRecordBuffer.newSinkRecord("ignored", 1);
+        when(records.getProcessedRecord(record)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        AsyncS3TvfWriter writer = writer(options(1024, 100), store, load, records);
+        try {
+            writer.insert(record);
+            writer.commitFlush();
+        } finally {
+            verify(load, never()).load(anyString(), anyList());
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testUploadFailureCanBeResetForRetry() throws Exception {
+        RecordingObjectStore store = new RecordingObjectStore();
+        store.putFailure = new IOException("upload failed");
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord record = TestRecordBuffer.newSinkRecord("ignored", 1);
+        when(records.getProcessedRecord(record)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        AsyncS3TvfWriter writer = writer(options(1024, 100), store, load, records);
+        try {
+            writer.insert(record);
+            try {
+                writer.commitFlush();
+                Assert.fail("Expected upload to fail");
+            } catch (DorisException expected) {
+                // Reset the failed batch before Kafka Connect retries the same records.
+            }
+
+            writer.resetAfterUploadFailure();
+            store.putFailure = null;
+            writer.insert(record);
+            writer.commitFlush();
+
+            Assert.assertEquals(1, store.objects.size());
+            verify(load).load(anyString(), anyList());
+        } finally {
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testCommittedObjectsRemainStaged() throws Exception {
+        RecordingObjectStore store = new RecordingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord record = TestRecordBuffer.newSinkRecord("ignored", 1);
+        when(records.getProcessedRecord(record)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        AsyncS3TvfWriter writer = writer(options(1024, 100), store, load, records);
+
+        writer.insert(record);
+        writer.commitFlush();
+
+        verify(load).load(anyString(), anyList());
+        Assert.assertEquals(1, store.objects.size());
+        writer.close();
+    }
+
+    @Test
+    public void testLoadFailureKeepsSameBatchForRetry() throws Exception {
+        RecordingObjectStore store = new RecordingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        doThrow(new DorisException("failed")).doNothing().when(load).load(anyString(), anyList());
+        RecordService records = mock(RecordService.class);
+        SinkRecord record = TestRecordBuffer.newSinkRecord("ignored", 1);
+        when(records.getProcessedRecord(record)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        AsyncS3TvfWriter writer = writer(options(1024, 100), store, load, records);
+        writer.insert(record);
+
+        try {
+            writer.commitFlush();
+            Assert.fail("Expected first commit to fail");
+        } catch (DorisException expected) {
+            // Retry the same batch so label reconciliation remains possible.
+        }
+        writer.commitFlush();
+
+        ArgumentCaptor<String> labels = ArgumentCaptor.forClass(String.class);
+        verify(load, org.mockito.Mockito.times(2)).load(labels.capture(), anyList());
+        Assert.assertEquals(labels.getAllValues().get(0), labels.getAllValues().get(1));
+        Assert.assertEquals(1, store.objects.size());
+        writer.close();
+    }
+
+    private static AsyncS3TvfWriter writer(
+            DorisOptions options, S3ObjectStore store, S3TvfLoad load, RecordService records) {
+        return new AsyncS3TvfWriter(
+                "demo.orders",
+                "orders-topic",
+                -1,
+                options,
+                mock(ConnectionProvider.class),
+                mock(DorisSystemService.class),
+                mock(DorisConnectMonitor.class),
+                records,
+                store,
+                load,
+                () -> BATCH_UUID,
+                Executors.newSingleThreadExecutor());
+    }
+
+    private static DorisOptions options(int bufferSize, int recordCount) throws IOException {
+        InputStream stream =
+                AsyncS3TvfWriterTest.class
+                        .getClassLoader()
+                        .getResourceAsStream("doris-connector-sink.properties");
+        Properties properties = new Properties();
+        properties.load(stream);
+        DorisSinkConnectorConfig.setDefaultValues((Map) properties);
+        properties.put("task_id", "7");
+        properties.put(DorisSinkConnectorConfig.NAME, "connector");
+        properties.put(DorisSinkConnectorConfig.DORIS_DATABASE, "");
+        properties.put(DorisSinkConnectorConfig.LABEL_PREFIX, "tvf");
+        properties.put(DorisSinkConnectorConfig.LOAD_MODEL, "tvf");
+        properties.put(DorisSinkConnectorConfig.ENABLE_COMBINE_FLUSH, "true");
+        properties.put(DorisSinkConnectorConfig.DELIVERY_GUARANTEE, "at_least_once");
+        properties.put(DorisSinkConnectorConfig.BUFFER_SIZE_BYTES, String.valueOf(bufferSize));
+        properties.put(DorisSinkConnectorConfig.BUFFER_COUNT_RECORDS, String.valueOf(recordCount));
+        properties.put(DorisSinkConnectorConfig.SINK_S3_ENDPOINT, "https://s3.example.com");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_REGION, "us-east-1");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_BUCKET, "staging");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_PREFIX, "objects");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_ACCESS_KEY, "access-key");
+        properties.put(DorisSinkConnectorConfig.SINK_S3_SECRET_KEY, "secret-key");
+        properties.put(DorisSinkConnectorConfig.STREAM_LOAD_PROP_PREFIX + "columns", "id,name");
+        return new DorisOptions((Map) properties);
+    }
+
+    private static class RecordingObjectStore implements S3ObjectStore {
+        protected final Map<String, byte[]> objects = new LinkedHashMap<>();
+        private IOException putFailure;
+
+        @Override
+        public synchronized void put(String objectKey, byte[] content) throws IOException {
+            if (putFailure != null) {
+                throw putFailure;
+            }
+            objects.put(objectKey, content);
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class BlockingObjectStore extends RecordingObjectStore {
+        private final CountDownLatch uploadStarted = new CountDownLatch(1);
+        private final CountDownLatch continueUpload = new CountDownLatch(1);
+
+        @Override
+        public void put(String objectKey, byte[] content) throws IOException {
+            uploadStarted.countDown();
+            try {
+                continueUpload.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Upload interrupted", e);
+            }
+            super.put(objectKey, content);
+        }
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriterTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/AsyncS3TvfWriterTest.java
@@ -35,9 +35,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.doris.kafka.connector.cfg.DorisOptions;
 import org.apache.doris.kafka.connector.cfg.DorisSinkConnectorConfig;
 import org.apache.doris.kafka.connector.connection.ConnectionProvider;
@@ -53,8 +58,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 public class AsyncS3TvfWriterTest {
-    private static final String BATCH_UUID = "550e8400-e29b-41d4-a716-446655440000";
-    private static final String COMPACT_UUID = "550e8400e29b41d4a716446655440000";
+    private static final String LABEL_PREFIX = "tvf_demo_orders_";
 
     @Test
     public void testUsesTaskIdAndOneBatchLabelForAllFiles() throws Exception {
@@ -72,17 +76,42 @@ public class AsyncS3TvfWriterTest {
         writer.insert(second);
         writer.commitFlush();
 
-        String label = "tvf_demo_orders_" + COMPACT_UUID;
-        String directory = "objects/tvf/demo_orders/" + COMPACT_UUID + "/";
+        ArgumentCaptor<String> labelCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<List> objectKeys = ArgumentCaptor.forClass(List.class);
+        verify(load).load(labelCaptor.capture(), objectKeys.capture());
+        String label = labelCaptor.getValue();
+        Assert.assertTrue(label.matches(LABEL_PREFIX + "[0-9a-f]{32}"));
+        String batchUuid = label.substring(LABEL_PREFIX.length());
+        String directory = "objects/tvf/demo_orders/" + batchUuid + "/";
         Assert.assertEquals(2, store.objects.size());
         Assert.assertTrue(store.objects.containsKey(directory + label + "_7_0.json"));
         Assert.assertTrue(store.objects.containsKey(directory + label + "_7_1.json"));
 
-        ArgumentCaptor<List> objectKeys = ArgumentCaptor.forClass(List.class);
-        verify(load).load(org.mockito.ArgumentMatchers.eq(label), objectKeys.capture());
         Assert.assertEquals(
                 Arrays.asList(directory + label + "_7_0.json", directory + label + "_7_1.json"),
                 objectKeys.getValue());
+        writer.close();
+    }
+
+    @Test
+    public void testSuccessfulCommitStartsNewBatch() throws Exception {
+        RecordingObjectStore store = new RecordingObjectStore();
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord record = TestRecordBuffer.newSinkRecord("ignored", 1);
+        when(records.getProcessedRecord(record)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        AsyncS3TvfWriter writer = writer(options(1024, 100), store, load, records);
+
+        writer.insert(record);
+        writer.commitFlush();
+        writer.insert(record);
+        writer.commitFlush();
+
+        ArgumentCaptor<String> labels = ArgumentCaptor.forClass(String.class);
+        verify(load, org.mockito.Mockito.times(2)).load(labels.capture(), anyList());
+        Assert.assertTrue(labels.getAllValues().get(0).matches(LABEL_PREFIX + "[0-9a-f]{32}"));
+        Assert.assertTrue(labels.getAllValues().get(1).matches(LABEL_PREFIX + "[0-9a-f]{32}"));
+        Assert.assertNotEquals(labels.getAllValues().get(0), labels.getAllValues().get(1));
         writer.close();
     }
 
@@ -226,6 +255,42 @@ public class AsyncS3TvfWriterTest {
     }
 
     @Test
+    public void testResetDrainsDequeuedUploadBeforeClearingFailure() throws Exception {
+        PausingUploadQueue uploadQueue = new PausingUploadQueue();
+        FailFirstUploadObjectStore store = new FailFirstUploadObjectStore(uploadQueue);
+        S3TvfLoad load = mock(S3TvfLoad.class);
+        RecordService records = mock(RecordService.class);
+        SinkRecord first = TestRecordBuffer.newSinkRecord("ignored", 1);
+        SinkRecord second = TestRecordBuffer.newSinkRecord("ignored", 2);
+        when(records.getProcessedRecord(first)).thenReturn("{\"id\":1,\"name\":\"first\"}");
+        when(records.getProcessedRecord(second)).thenReturn("{\"id\":2,\"name\":\"second\"}");
+        AsyncS3TvfWriter writer = writer(options(1024, 1), store, load, records, uploadQueue);
+        ExecutorService resetExecutor = Executors.newSingleThreadExecutor();
+
+        try {
+            writer.insert(first);
+            try {
+                writer.insert(second);
+            } catch (DorisException expected) {
+                // The second upload was queued before the first upload failure became visible.
+            }
+            Assert.assertTrue(uploadQueue.secondUploadDequeued.await(5, TimeUnit.SECONDS));
+
+            Future<?> reset = resetExecutor.submit(writer::resetAfterUploadFailure);
+            Assert.assertTrue(uploadQueue.resetStarted.await(5, TimeUnit.SECONDS));
+            uploadQueue.continueSecondUpload.countDown();
+
+            Assert.assertTrue(uploadQueue.secondUploadFinished.await(5, TimeUnit.SECONDS));
+            reset.get(5, TimeUnit.SECONDS);
+            Assert.assertTrue(store.objects.isEmpty());
+        } finally {
+            uploadQueue.continueSecondUpload.countDown();
+            resetExecutor.shutdownNow();
+            writer.close();
+        }
+    }
+
+    @Test
     public void testCommittedObjectsRemainStaged() throws Exception {
         RecordingObjectStore store = new RecordingObjectStore();
         S3TvfLoad load = mock(S3TvfLoad.class);
@@ -243,7 +308,7 @@ public class AsyncS3TvfWriterTest {
     }
 
     @Test
-    public void testLoadFailureKeepsSameBatchForRetry() throws Exception {
+    public void testLoadFailureEndsBatchBeforeRetry() throws Exception {
         RecordingObjectStore store = new RecordingObjectStore();
         S3TvfLoad load = mock(S3TvfLoad.class);
         doThrow(new DorisException("failed")).doNothing().when(load).load(anyString(), anyList());
@@ -257,19 +322,34 @@ public class AsyncS3TvfWriterTest {
             writer.commitFlush();
             Assert.fail("Expected first commit to fail");
         } catch (DorisException expected) {
-            // Retry the same batch so label reconciliation remains possible.
+            // Kafka Connect can replay the records after the failed commit.
         }
+        writer.insert(record);
         writer.commitFlush();
 
         ArgumentCaptor<String> labels = ArgumentCaptor.forClass(String.class);
-        verify(load, org.mockito.Mockito.times(2)).load(labels.capture(), anyList());
-        Assert.assertEquals(labels.getAllValues().get(0), labels.getAllValues().get(1));
-        Assert.assertEquals(1, store.objects.size());
+        ArgumentCaptor<List> objectKeys = ArgumentCaptor.forClass(List.class);
+        verify(load, org.mockito.Mockito.times(2)).load(labels.capture(), objectKeys.capture());
+        Assert.assertNotEquals(labels.getAllValues().get(0), labels.getAllValues().get(1));
+        Assert.assertEquals(1, objectKeys.getAllValues().get(0).size());
+        Assert.assertEquals(1, objectKeys.getAllValues().get(1).size());
+        Assert.assertNotEquals(
+                objectKeys.getAllValues().get(0).get(0), objectKeys.getAllValues().get(1).get(0));
+        Assert.assertEquals(2, store.objects.size());
         writer.close();
     }
 
     private static AsyncS3TvfWriter writer(
             DorisOptions options, S3ObjectStore store, S3TvfLoad load, RecordService records) {
+        return writer(options, store, load, records, new LinkedBlockingQueue<>(1));
+    }
+
+    private static AsyncS3TvfWriter writer(
+            DorisOptions options,
+            S3ObjectStore store,
+            S3TvfLoad load,
+            RecordService records,
+            BlockingQueue<Runnable> uploadQueue) {
         return new AsyncS3TvfWriter(
                 "demo.orders",
                 "orders-topic",
@@ -281,8 +361,8 @@ public class AsyncS3TvfWriterTest {
                 records,
                 store,
                 load,
-                () -> BATCH_UUID,
-                Executors.newSingleThreadExecutor());
+                Executors.newSingleThreadExecutor(),
+                uploadQueue);
     }
 
     private static DorisOptions options(int bufferSize, int recordCount) throws IOException {
@@ -342,6 +422,74 @@ public class AsyncS3TvfWriterTest {
                 throw new IOException("Upload interrupted", e);
             }
             super.put(objectKey, content);
+        }
+    }
+
+    private static class FailFirstUploadObjectStore extends RecordingObjectStore {
+        private final PausingUploadQueue uploadQueue;
+        private final AtomicInteger uploadCount = new AtomicInteger();
+
+        private FailFirstUploadObjectStore(PausingUploadQueue uploadQueue) {
+            this.uploadQueue = uploadQueue;
+        }
+
+        @Override
+        public void put(String objectKey, byte[] content) throws IOException {
+            if (uploadCount.incrementAndGet() == 1) {
+                try {
+                    uploadQueue.secondUploadQueued.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Upload interrupted", e);
+                }
+                throw new IOException("first upload failed");
+            }
+            super.put(objectKey, content);
+        }
+    }
+
+    private static class PausingUploadQueue extends LinkedBlockingQueue<Runnable> {
+        private final AtomicInteger putCount = new AtomicInteger();
+        private final AtomicInteger takeCount = new AtomicInteger();
+        private final CountDownLatch secondUploadQueued = new CountDownLatch(1);
+        private final CountDownLatch secondUploadDequeued = new CountDownLatch(1);
+        private final CountDownLatch continueSecondUpload = new CountDownLatch(1);
+        private final CountDownLatch secondUploadFinished = new CountDownLatch(1);
+        private final CountDownLatch resetStarted = new CountDownLatch(1);
+
+        private PausingUploadQueue() {
+            super(1);
+        }
+
+        @Override
+        public void put(Runnable upload) throws InterruptedException {
+            super.put(upload);
+            if (putCount.incrementAndGet() == 2) {
+                secondUploadQueued.countDown();
+            }
+        }
+
+        @Override
+        public Runnable take() throws InterruptedException {
+            Runnable upload = super.take();
+            if (takeCount.incrementAndGet() != 2) {
+                return upload;
+            }
+            secondUploadDequeued.countDown();
+            continueSecondUpload.await();
+            return () -> {
+                try {
+                    upload.run();
+                } finally {
+                    secondUploadFinished.countDown();
+                }
+            };
+        }
+
+        @Override
+        public void clear() {
+            super.clear();
+            resetStarted.countDown();
         }
     }
 }

--- a/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3ClientObjectStoreTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3ClientObjectStoreTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+public class S3ClientObjectStoreTest {
+
+    @Test
+    public void testPutUsesExactBucketKeyAndJsonLinesContentType() throws Exception {
+        S3Client client = Mockito.mock(S3Client.class);
+        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+        S3ClientObjectStore store = new S3ClientObjectStore(client, "staging");
+
+        store.put("kafka/orders/file.json", "{\"id\":1}\n".getBytes(StandardCharsets.UTF_8));
+
+        ArgumentCaptor<PutObjectRequest> request = ArgumentCaptor.forClass(PutObjectRequest.class);
+        ArgumentCaptor<RequestBody> body = ArgumentCaptor.forClass(RequestBody.class);
+        verify(client).putObject(request.capture(), body.capture());
+        Assert.assertEquals("staging", request.getValue().bucket());
+        Assert.assertEquals("kafka/orders/file.json", request.getValue().key());
+        Assert.assertEquals("application/x-ndjson", request.getValue().contentType());
+        Assert.assertEquals(
+                "{\"id\":1}\n",
+                IOUtils.toString(
+                        body.getValue().contentStreamProvider().newStream(),
+                        StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoadTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoadTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.doris.kafka.connector.cfg.S3TvfOptions;
+import org.apache.doris.kafka.connector.connection.ConnectionProvider;
+import org.apache.doris.kafka.connector.exception.DorisException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+public class S3TvfLoadTest {
+    private ConnectionProvider connectionProvider;
+    private Connection connection;
+    private Statement statement;
+    private String insertSql;
+
+    @Before
+    public void setUp() throws Exception {
+        connectionProvider = mock(ConnectionProvider.class);
+        connection = mock(Connection.class);
+        statement = mock(Statement.class);
+        when(connectionProvider.getOrEstablishConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        insertSql =
+                sqlBuilder().buildInsertSql("demo", "orders", "label", files(), columns(), false);
+    }
+
+    @Test
+    public void testSetsSessionVariablesBeforeInsert() throws Exception {
+        Map<String, String> sessionVariables = new LinkedHashMap<>();
+        sessionVariables.put("enable_unique_key_partial_update", "true");
+        S3TvfLoad load = load(sessionVariables, 1);
+
+        load.load("label", files());
+
+        InOrder order = inOrder(statement);
+        order.verify(statement).execute("SET SESSION enable_unique_key_partial_update = 'true'");
+        order.verify(statement).execute(insertSql);
+    }
+
+    @Test
+    public void testRetriesTransientInsertFailure() throws Exception {
+        when(statement.execute(insertSql))
+                .thenThrow(new SQLException("temporary"))
+                .thenReturn(true);
+
+        load(Collections.emptyMap(), 1).load("label", files());
+
+        verify(statement, org.mockito.Mockito.times(2)).execute(insertSql);
+        verify(statement, never()).executeQuery(anyString());
+    }
+
+    @Test
+    public void testLabelAlreadyUsedFinishedIsSuccess() throws Exception {
+        when(statement.execute(insertSql))
+                .thenThrow(new SQLException("Label [label] has already been used"));
+        doReturn(resultSet("FINISHED"))
+                .when(statement)
+                .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
+
+        load(Collections.emptyMap(), 0).load("label", files());
+
+        verify(statement).executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
+    }
+
+    @Test
+    public void testFinishedWinsOverCancelledRows() throws Exception {
+        when(statement.execute(insertSql))
+                .thenThrow(new SQLException("Label [label] has already been used"));
+        doReturn(resultSet("CANCELLED", "FINISHED"))
+                .when(statement)
+                .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
+
+        load(Collections.emptyMap(), 0).load("label", files());
+    }
+
+    @Test
+    public void testCancelsActiveLabelAndAcceptsConcurrentFinish() throws Exception {
+        when(statement.execute(insertSql))
+                .thenThrow(new SQLException("Label [label] has already been used"));
+        doReturn(resultSet("LOADING"), resultSet("FINISHED"))
+                .when(statement)
+                .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
+
+        load(Collections.emptyMap(), 1).load("label", files());
+
+        verify(statement).execute("CANCEL LOAD FROM `demo` WHERE LABEL = 'label'");
+        verify(statement, org.mockito.Mockito.times(2))
+                .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
+    }
+
+    @Test
+    public void testCancelledLabelRetriesInsert() throws Exception {
+        when(statement.execute(insertSql))
+                .thenThrow(new SQLException("Label [label] has already been used"))
+                .thenReturn(true);
+        doReturn(resultSet("CANCELLED"))
+                .when(statement)
+                .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
+
+        load(Collections.emptyMap(), 1).load("label", files());
+
+        verify(statement, org.mockito.Mockito.times(2)).execute(insertSql);
+    }
+
+    @Test(expected = DorisException.class)
+    public void testRejectsInvalidSessionVariableName() throws Exception {
+        load(Collections.singletonMap("invalid-name", "true"), 0).load("label", files());
+    }
+
+    @Test
+    public void testFailureDoesNotExposeSqlOrCredentials() throws Exception {
+        when(statement.execute(insertSql)).thenThrow(new SQLException("temporary"));
+        try {
+            load(Collections.emptyMap(), 0).load("label", files());
+            Assert.fail("Expected load failure");
+        } catch (DorisException e) {
+            Assert.assertFalse(e.getMessage().contains("secret-key"));
+            Assert.assertFalse(e.getMessage().contains("INSERT INTO"));
+            Assert.assertTrue(e.getMessage().contains("label"));
+        }
+    }
+
+    private S3TvfLoad load(Map<String, String> sessionVariables, int maxRetries) {
+        return new S3TvfLoad(
+                connectionProvider,
+                sqlBuilder(),
+                "demo",
+                "orders",
+                columns(),
+                false,
+                sessionVariables,
+                maxRetries);
+    }
+
+    private static S3TvfSqlBuilder sqlBuilder() {
+        S3TvfOptions options =
+                S3TvfOptions.builder()
+                        .setEndpoint("https://s3.example.com")
+                        .setRegion("us-east-1")
+                        .setBucket("staging")
+                        .setPrefix("objects")
+                        .setAccessKey("access-key")
+                        .setSecretKey("secret-key")
+                        .build();
+        return new S3TvfSqlBuilder(options);
+    }
+
+    private static java.util.List<String> files() {
+        return Arrays.asList("objects/file.json");
+    }
+
+    private static java.util.List<String> columns() {
+        return Arrays.asList("id", "name");
+    }
+
+    private static ResultSet resultSet(String... states) throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        org.mockito.stubbing.OngoingStubbing<Boolean> next = when(resultSet.next());
+        for (int index = 0; index < states.length; index++) {
+            next = next.thenReturn(true);
+        }
+        next.thenReturn(false);
+
+        org.mockito.stubbing.OngoingStubbing<String> state = when(resultSet.getString("State"));
+        for (String value : states) {
+            state = state.thenReturn(value);
+        }
+        return resultSet;
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoadTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfLoadTest.java
@@ -64,7 +64,7 @@ public class S3TvfLoadTest {
     public void testSetsSessionVariablesBeforeInsert() throws Exception {
         Map<String, String> sessionVariables = new LinkedHashMap<>();
         sessionVariables.put("enable_unique_key_partial_update", "true");
-        S3TvfLoad load = load(sessionVariables, 1);
+        S3TvfLoad load = load(sessionVariables);
 
         load.load("label", files());
 
@@ -79,7 +79,7 @@ public class S3TvfLoadTest {
                 .thenThrow(new SQLException("temporary"))
                 .thenReturn(true);
 
-        load(Collections.emptyMap(), 1).load("label", files());
+        load(Collections.emptyMap()).load("label", files());
 
         verify(statement, org.mockito.Mockito.times(2)).execute(insertSql);
         verify(statement, never()).executeQuery(anyString());
@@ -93,7 +93,7 @@ public class S3TvfLoadTest {
                 .when(statement)
                 .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
 
-        load(Collections.emptyMap(), 0).load("label", files());
+        load(Collections.emptyMap()).load("label", files());
 
         verify(statement).executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
     }
@@ -106,7 +106,7 @@ public class S3TvfLoadTest {
                 .when(statement)
                 .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
 
-        load(Collections.emptyMap(), 0).load("label", files());
+        load(Collections.emptyMap()).load("label", files());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class S3TvfLoadTest {
                 .when(statement)
                 .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
 
-        load(Collections.emptyMap(), 1).load("label", files());
+        load(Collections.emptyMap()).load("label", files());
 
         verify(statement).execute("CANCEL LOAD FROM `demo` WHERE LABEL = 'label'");
         verify(statement, org.mockito.Mockito.times(2))
@@ -133,30 +133,31 @@ public class S3TvfLoadTest {
                 .when(statement)
                 .executeQuery("SHOW LOAD FROM `demo` WHERE LABEL = 'label'");
 
-        load(Collections.emptyMap(), 1).load("label", files());
+        load(Collections.emptyMap()).load("label", files());
 
         verify(statement, org.mockito.Mockito.times(2)).execute(insertSql);
     }
 
     @Test(expected = DorisException.class)
     public void testRejectsInvalidSessionVariableName() throws Exception {
-        load(Collections.singletonMap("invalid-name", "true"), 0).load("label", files());
+        load(Collections.singletonMap("invalid-name", "true")).load("label", files());
     }
 
     @Test
     public void testFailureDoesNotExposeSqlOrCredentials() throws Exception {
         when(statement.execute(insertSql)).thenThrow(new SQLException("temporary"));
         try {
-            load(Collections.emptyMap(), 0).load("label", files());
+            load(Collections.emptyMap()).load("label", files());
             Assert.fail("Expected load failure");
         } catch (DorisException e) {
             Assert.assertFalse(e.getMessage().contains("secret-key"));
             Assert.assertFalse(e.getMessage().contains("INSERT INTO"));
             Assert.assertTrue(e.getMessage().contains("label"));
         }
+        verify(statement, org.mockito.Mockito.times(4)).execute(insertSql);
     }
 
-    private S3TvfLoad load(Map<String, String> sessionVariables, int maxRetries) {
+    private S3TvfLoad load(Map<String, String> sessionVariables) {
         return new S3TvfLoad(
                 connectionProvider,
                 sqlBuilder(),
@@ -164,8 +165,7 @@ public class S3TvfLoadTest {
                 "orders",
                 columns(),
                 false,
-                sessionVariables,
-                maxRetries);
+                sessionVariables);
     }
 
     private static S3TvfSqlBuilder sqlBuilder() {

--- a/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfRecordSerializerTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfRecordSerializerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import java.util.Arrays;
+import org.apache.doris.kafka.connector.exception.DataFormatException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3TvfRecordSerializerTest {
+
+    @Test
+    public void testSelectsColumnsAndNormalizesDeleteSign() {
+        S3TvfRecordSerializer serializer =
+                new S3TvfRecordSerializer(Arrays.asList("id", "name"), true);
+
+        String serialized =
+                serializer.serialize(
+                        "{\"extra\":9,\"name\":null,\"id\":7,\"__DORIS_DELETE_SIGN__\":\"1\"}");
+
+        Assert.assertEquals("{\"id\":7,\"name\":null,\"__doris_delete_sign__\":\"1\"}", serialized);
+    }
+
+    @Test
+    public void testFillsMissingColumnsAndDefaultsDeleteSign() {
+        S3TvfRecordSerializer serializer =
+                new S3TvfRecordSerializer(Arrays.asList("id", "name"), true);
+
+        Assert.assertEquals(
+                "{\"id\":7,\"name\":null,\"__doris_delete_sign__\":\"0\"}",
+                serializer.serialize("{\"id\":7}"));
+    }
+
+    @Test(expected = DataFormatException.class)
+    public void testRejectsMultipleJsonObjects() {
+        new S3TvfRecordSerializer(Arrays.asList("id", "name"), false)
+                .serialize("{\"id\":1}\n{\"name\":\"doris\",\"id\":2}");
+    }
+
+    @Test(expected = DataFormatException.class)
+    public void testRejectsNonObjectJsonLine() {
+        new S3TvfRecordSerializer(Arrays.asList("id"), false).serialize("[1,2]");
+    }
+}

--- a/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfSqlBuilderTest.java
+++ b/src/test/java/org/apache/doris/kafka/connector/writer/s3/S3TvfSqlBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.doris.kafka.connector.writer.s3;
+
+import java.util.Arrays;
+import org.apache.doris.kafka.connector.cfg.S3TvfOptions;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3TvfSqlBuilderTest {
+
+    @Test
+    public void testBuildInsertWithExactObjectsAndColumns() {
+        S3TvfSqlBuilder builder = new S3TvfSqlBuilder(options("access-key", "secret-key"));
+
+        String sql =
+                builder.buildInsertSql(
+                        "demo",
+                        "orders",
+                        "prefix_demo_orders_batch",
+                        Arrays.asList("objects/first.json", "objects/second.json"),
+                        Arrays.asList("id", "name"),
+                        true);
+
+        Assert.assertEquals(
+                "INSERT INTO `demo`.`orders` WITH LABEL `prefix_demo_orders_batch` "
+                        + "(`id`,`name`,`__DORIS_DELETE_SIGN__`) SELECT "
+                        + "`id`,`name`,`__DORIS_DELETE_SIGN__` FROM S3("
+                        + "'uri' = 's3://staging/{objects/first.json,objects/second.json}',"
+                        + "'s3.access_key' = 'access-key','s3.secret_key' = 'secret-key',"
+                        + "'s3.region' = 'us-east-1','s3.endpoint' = 'https://s3.example.com',"
+                        + "'format' = 'json','read_json_by_line' = 'true','use_path_style' = 'true')",
+                sql);
+    }
+
+    @Test
+    public void testQuotesIdentifiersAndLiterals() {
+        S3TvfSqlBuilder builder = new S3TvfSqlBuilder(options("a'k", "s\\k"));
+
+        String sql =
+                builder.buildInsertSql(
+                        "de`mo",
+                        "orders",
+                        "la`bel",
+                        Arrays.asList("objects/first.json"),
+                        Arrays.asList("na`me"),
+                        false);
+
+        Assert.assertTrue(sql.contains("`de``mo`.`orders`"));
+        Assert.assertTrue(sql.contains("WITH LABEL `la``bel`"));
+        Assert.assertTrue(sql.contains("`na``me`"));
+        Assert.assertTrue(sql.contains("'s3.access_key' = 'a\\'k'"));
+        Assert.assertTrue(sql.contains("'s3.secret_key' = 's\\\\k'"));
+        Assert.assertFalse(builder.toString().contains("a'k"));
+        Assert.assertFalse(builder.toString().contains("s\\k"));
+    }
+
+    private static S3TvfOptions options(String accessKey, String secretKey) {
+        return S3TvfOptions.builder()
+                .setEndpoint("https://s3.example.com")
+                .setRegion("us-east-1")
+                .setBucket("staging")
+                .setPrefix("objects")
+                .setAccessKey(accessKey)
+                .setSecretKey(secretKey)
+                .setPathStyleAccess(true)
+                .build();
+    }
+}

--- a/src/test/resources/docker/doris/fe.conf
+++ b/src/test/resources/docker/doris/fe.conf
@@ -27,7 +27,7 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 LOG_DIR = ${DORIS_HOME}/log
 
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_DIR -Xlog:gc*,classhisto*=trace:$LOG_DIR/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
+JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -XX:-UseContainerSupport -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_DIR -Xlog:gc*,classhisto*=trace:$LOG_DIR/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
 
 # Set your own JAVA_HOME
 # JAVA_HOME=/path/to/jdk/


### PR DESCRIPTION
## Summary

- add S3 TVF sink mode for combined at-least-once writes
- stage JSON Lines files asynchronously in S3 and load them through labeled TVF inserts
- add TVF configuration validation, retry handling, unit coverage, and MinIO-based end-to-end cases

## Testing

- Not run (per review request)